### PR TITLE
fix max width logic

### DIFF
--- a/examples/bubbletea/main.go
+++ b/examples/bubbletea/main.go
@@ -112,7 +112,7 @@ func (m Model) Init() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.width = max(msg.Width, maxWidth) - m.styles.Base.GetHorizontalFrameSize()
+		m.width = min(msg.Width, maxWidth) - m.styles.Base.GetHorizontalFrameSize()
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "esc", "ctrl+c", "q":


### PR DESCRIPTION
To ensure the form is no greater than maxWidth, we need to take the minimum among the desired width and maxWidth.

Taking the maximum among these values effectively changes the logic to ensure the form is no less than maxWidth (in which case, it should probably be called minWidth).