### PR TITLE
fix: confirm sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Prompt the user to confirm (Yes or No).
 
 ```go
 huh.NewConfirm().
-    Title("You sure?").
+    Title("Are you sure?").
     Affirmative("Yes!").
     Negative("No.").
     Value(&confirm)


### PR DESCRIPTION
Hi! I changed it because the string in the sample code for [Confirm](https://github.com/charmbracelet/huh?tab=readme-ov-file#confirm) in the README and the video did not match.

### Before
![huh_before](https://github.com/charmbracelet/huh/assets/41510086/afd6bc74-37cc-4d7a-807e-7ffacb9c19b0)


### After
![huh_after](https://github.com/charmbracelet/huh/assets/41510086/3a639bf4-827c-4c35-b0e1-c2698fde2a8b)
