### PR TITLE
docs: fix repeated word "mode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple, powerful library for building interactive forms and prompts in the ter
 
 `huh?` is easy to use in a standalone fashion, can be
 [integrated into a Bubble Tea application](#what-about-bubble-tea), and contains
-a first-class [accessible mode](#accessibility) mode for screen readers.
+a first-class [accessible mode](#accessibility) for screen readers.
 
 The above example is running from a single Go program ([source](./examples/burger/main.go)).
 


### PR DESCRIPTION
The word "mode" is repeated twice in readme.

![CleanShot 2023-12-14 at 09 30 32@2x](https://github.com/charmbracelet/huh/assets/2306588/ee4843fd-8cf2-4f71-8ced-4f5f905c73e9)
