### PR TITLE
feat(options): simple options (key = value)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,13 +205,13 @@ Prompt the user to select multiple (zero or more) options from a list.
 ```go
 huh.NewMultiSelect[string]().
     Options(
-        huh.NewOption("Lettuce", "Lettuce").Selected(true),
-        huh.NewOption("Tomatoes", "Tomatoes").Selected(true),
-        huh.NewOption("Charm Sauce", "Charm Sauce"),
-        huh.NewOption("Jalapeños", "Jalapeños"),
-        huh.NewOption("Cheese", "Cheese"),
-        huh.NewOption("Vegan Cheese", "Vegan Cheese"),
-        huh.NewOption("Nutella", "Nutella"),
+        huh.NewSimpleOption("Lettuce").Selected(true),
+        huh.NewSimpleOption("Tomatoes").Selected(true),
+        huh.NewSimpleOption("Charm Sauce"),
+        huh.NewSimpleOption("Jalapeños"),
+        huh.NewSimpleOption("Cheese"),
+        huh.NewSimpleOption("Vegan Cheese"),
+        huh.NewSimpleOption("Nutella"),
     ).
     Title("Toppings").
     Limit(4).

--- a/examples/burger/main.go
+++ b/examples/burger/main.go
@@ -81,13 +81,13 @@ func main() {
 				Title("Toppings").
 				Description("Choose up to 4.").
 				Options(
-					huh.NewOption("Lettuce", "Lettuce").Selected(true),
-					huh.NewOption("Tomatoes", "Tomatoes").Selected(true),
-					huh.NewOption("Charm Sauce", "Charm Sauce"),
-					huh.NewOption("Jalapeños", "Jalapeños"),
-					huh.NewOption("Cheese", "Cheese"),
-					huh.NewOption("Vegan Cheese", "Vegan Cheese"),
-					huh.NewOption("Nutella", "Nutella"),
+					huh.NewSimpleOption("Lettuce").Selected(true),
+					huh.NewSimpleOption("Tomatoes").Selected(true),
+					huh.NewSimpleOption("Charm Sauce"),
+					huh.NewSimpleOption("Jalapeños"),
+					huh.NewSimpleOption("Cheese"),
+					huh.NewSimpleOption("Vegan Cheese"),
+					huh.NewSimpleOption("Nutella"),
 				).
 				Validate(func(t []string) error {
 					if len(t) <= 0 {

--- a/option.go
+++ b/option.go
@@ -26,6 +26,11 @@ func NewOption[T any](key string, value T) Option[T] {
 	return Option[T]{Key: key, Value: value}
 }
 
+// NewSimpleOption returns a new select option with the same key and value.
+func NewSimpleOption(key string) Option[string] {
+	return Option[string]{Key: key, Value: key}
+}
+
 // Selected sets whether the option is currently selected.
 func (o Option[T]) Selected(selected bool) Option[T] {
 	o.selected = selected


### PR DESCRIPTION
This PR adds the method `NewSimpleOption(key string)`, which is a more idiomatic way to create options that have the same key and value.

The main advantages of such a method are:
- When passing an expression, there is no need to introduce a temporary variable or to write it twice
- When passing a string literal, there is no risk of there being a typo so that key != value
- Serves the DRY principle

IMO this also makes the code easier to read, as it is not instantly obvious why there are 2 parameters with the same value when using `NewOption`. I also think this use case is common enough to warrant a dedicated method for it. Let me know what you think of this suggestion 🙂