### PR TITLE
fix: prefill select and multiselect with value

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -11,7 +11,7 @@ import (
 )
 
 // MultiSelect is a form multi-select field.
-type MultiSelect[T any] struct {
+type MultiSelect[T comparable] struct {
 	value *[]T
 	key   string
 
@@ -38,7 +38,7 @@ type MultiSelect[T any] struct {
 }
 
 // NewMultiSelect returns a new multi-select field.
-func NewMultiSelect[T any]() *MultiSelect[T] {
+func NewMultiSelect[T comparable]() *MultiSelect[T] {
 	return &MultiSelect[T]{
 		options:  []Option[T]{},
 		value:    new([]T),
@@ -49,6 +49,14 @@ func NewMultiSelect[T any]() *MultiSelect[T] {
 // Value sets the value of the multi-select field.
 func (m *MultiSelect[T]) Value(value *[]T) *MultiSelect[T] {
 	m.value = value
+	for i, o := range m.options {
+		for _, v := range *value {
+			if o.Value == v {
+				m.options[i].selected = true
+				break
+			}
+		}
+	}
 	return m
 }
 

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -84,6 +84,15 @@ func (m *MultiSelect[T]) Options(options ...Option[T]) *MultiSelect[T] {
 	if len(options) <= 0 {
 		return m
 	}
+
+	for i, o := range options {
+		for _, v := range *m.value {
+			if o.Value == v {
+				options[i].selected = true
+				break
+			}
+		}
+	}
 	m.options = options
 	return m
 }

--- a/field_select.go
+++ b/field_select.go
@@ -92,9 +92,12 @@ func (s *Select[T]) Options(options ...Option[T]) *Select[T] {
 	s.options = options
 	s.filteredOptions = options
 
-	// Set the cursor to the last selected option.
+	// Set the cursor to the existing value or the last selected option.
 	for i, option := range options {
-		if option.selected {
+		if option.Value == *s.value {
+			s.selected = i
+			break
+		} else if option.selected {
 			s.selected = i
 		}
 	}

--- a/field_select.go
+++ b/field_select.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Select is a form select field.
-type Select[T any] struct {
+type Select[T comparable] struct {
 	value *T
 	key   string
 
@@ -40,7 +40,7 @@ type Select[T any] struct {
 }
 
 // NewSelect returns a new select field.
-func NewSelect[T any]() *Select[T] {
+func NewSelect[T comparable]() *Select[T] {
 	filter := textinput.New()
 	filter.Prompt = "/"
 
@@ -56,6 +56,12 @@ func NewSelect[T any]() *Select[T] {
 // Value sets the value of the select field.
 func (s *Select[T]) Value(value *T) *Select[T] {
 	s.value = value
+	for i, o := range s.options {
+		if o.Value == *value {
+			s.selected = i
+			break
+		}
+	}
 	return s
 }
 

--- a/option.go
+++ b/option.go
@@ -3,14 +3,14 @@ package huh
 import "fmt"
 
 // Option is an option for select fields.
-type Option[T any] struct {
+type Option[T comparable] struct {
 	Key      string
 	Value    T
 	selected bool
 }
 
 // NewOptions returns new options from a list of values.
-func NewOptions[T any](values ...T) []Option[T] {
+func NewOptions[T comparable](values ...T) []Option[T] {
 	options := make([]Option[T], len(values))
 	for i, o := range values {
 		options[i] = Option[T]{
@@ -22,7 +22,7 @@ func NewOptions[T any](values ...T) []Option[T] {
 }
 
 // NewOption returns a new select option.
-func NewOption[T any](key string, value T) Option[T] {
+func NewOption[T comparable](key string, value T) Option[T] {
 	return Option[T]{Key: key, Value: value}
 }
 


### PR DESCRIPTION
Fixes https://github.com/charmbracelet/huh/issues/55

Dev notes: I had to change the value generic types to `comparable` to make the comparison between `option.Value` and the received values possible. Also, it seems more correct.