### PR TITLE
fix: Select and MultiSelect height when unfocused

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -118,6 +118,7 @@ func (m *MultiSelect[T]) Height(height int) *MultiSelect[T] {
 	// What we really want to do is set the height of the viewport, but we
 	// need a theme applied before we can calcualate its height.
 	m.height = height
+	m.updateViewportHeight()
 	return m
 }
 
@@ -371,6 +372,7 @@ func (m *MultiSelect[T]) runAccessible() error {
 // WithTheme sets the theme of the multi-select field.
 func (m *MultiSelect[T]) WithTheme(theme *Theme) Field {
 	m.theme = theme
+	m.updateViewportHeight()
 	return m
 }
 

--- a/field_select.go
+++ b/field_select.go
@@ -114,6 +114,7 @@ func (s *Select[T]) Options(options ...Option[T]) *Select[T] {
 // exceeds the height, the select field will become scrollable.
 func (s *Select[T]) Height(height int) *Select[T] {
 	s.height = height
+	s.updateViewportHeight()
 	return s
 }
 
@@ -252,7 +253,7 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // updateViewportHeight updates the viewport size according to the Height setting
-// on this multi-select field.
+// on this select field.
 func (s *Select[T]) updateViewportHeight() {
 	// If no height is set size the viewport to the number of options.
 	if s.height <= 0 {
@@ -401,6 +402,7 @@ func (s *Select[T]) WithTheme(theme *Theme) Field {
 	s.theme = theme
 	s.filter.Cursor.Style = s.theme.Focused.TextInput.Cursor
 	s.filter.PromptStyle = s.theme.Focused.TextInput.Prompt
+	s.updateViewportHeight()
 	return s
 }
 


### PR DESCRIPTION
When `Select` or `MultiSelect` had a defined height for scrolling (kudos @meowgorithm!) and wasn't the first field in the group, the height was ignored and re-rendered only when focused.

![bug](https://github.com/charmbracelet/huh/assets/2306588/c36c3626-c84e-482e-b3ce-31b1653f4544)

Since the height is evaluated after the theming step, `updateViewportHeight` needs to be called in `WithTheme` and `Height` functions.

![fix](https://github.com/charmbracelet/huh/assets/2306588/a4991322-b371-42a7-b730-ee15b0875a36)
