### PR TITLE
fix: Select viewport on filtering

### DIFF
--- a/field_select.go
+++ b/field_select.go
@@ -245,6 +245,7 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if len(s.filteredOptions) > 0 {
 				s.selected = min(s.selected, len(s.filteredOptions)-1)
+				s.viewport.SetYOffset(clamp(s.selected, 0, len(s.filteredOptions)-s.viewport.Height))
 			}
 		}
 	}


### PR DESCRIPTION
When you move the `Select` cursor to the bottom and filter for something, the whole viewport moves beyond the top.

![bug](https://github.com/charmbracelet/huh/assets/2306588/11cee6ea-18be-44ba-80ab-161c80620753)

With this fix, I clamped the offset to the view on both top and bottom.

![fix](https://github.com/charmbracelet/huh/assets/2306588/c3e0a63b-b8c7-46c8-9d78-a6670036f89a)
