### PR TITLE
Set Default Theme on inputs

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -42,6 +42,7 @@ func NewConfirm() *Confirm {
 		affirmative: "Yes",
 		negative:    "No",
 		validate:    func(bool) error { return nil },
+		theme:       ThemeCharm(),
 	}
 }
 

--- a/field_input.go
+++ b/field_input.go
@@ -46,6 +46,7 @@ func NewInput() *Input {
 		value:     new(string),
 		textinput: input,
 		validate:  func(string) error { return nil },
+		theme:     ThemeCharm(),
 	}
 
 	return i

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -55,6 +55,7 @@ func NewMultiSelect[T comparable]() *MultiSelect[T] {
 		validate:  func([]T) error { return nil },
 		filtering: false,
 		filter:    filter,
+		theme:     ThemeCharm(),
 	}
 }
 

--- a/field_note.go
+++ b/field_note.go
@@ -50,6 +50,7 @@ func NewNote() *Note {
 	return &Note{
 		showNextButton: false,
 		renderer:       r,
+		theme:          ThemeCharm(),
 	}
 }
 

--- a/field_select.go
+++ b/field_select.go
@@ -53,6 +53,7 @@ func NewSelect[T comparable]() *Select[T] {
 		validate:  func(T) error { return nil },
 		filtering: false,
 		filter:    filter,
+		theme:     ThemeCharm(),
 	}
 }
 

--- a/field_text.go
+++ b/field_text.go
@@ -58,6 +58,7 @@ func NewText() *Text {
 		editorCmd:       editorCmd,
 		editorArgs:      editorArgs,
 		editorExtension: "md",
+		theme:           ThemeCharm(),
 	}
 
 	return t


### PR DESCRIPTION
Fixes https://github.com/charmbracelet/huh/issues/91

Addresses issue where standalone `Run` of input would panic when run in accessible mode.

This PR fixes this issue by setting all the default themes such that there is always a theme set on stand alone inputs (when running in accessible + standalone mode)