### PR TITLE
Expose autocomplete suggestions

### DIFF
--- a/examples/git/main.go
+++ b/examples/git/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	huh.NewForm(
 		huh.NewGroup(
-			huh.NewSelect[string]().Title("Type").Value(&commit).Options(huh.NewOptions(types...)...),
+			huh.NewInput().Title("Type").Value(&commit).Placeholder("feat").Suggestions(types),
 			huh.NewInput().Title("Scope").Value(&scope).Placeholder("scope"),
 		),
 		huh.NewGroup(

--- a/field_input.go
+++ b/field_input.go
@@ -89,6 +89,14 @@ func (i *Input) CharLimit(charlimit int) *Input {
 	return i
 }
 
+// Suggestions sets the suggestions to display for autocomplete in the input
+// field.
+func (i *Input) Suggestions(suggestions []string) *Input {
+	i.textinput.ShowSuggestions = len(suggestions) > 0
+	i.textinput.SetSuggestions(suggestions)
+	return i
+}
+
 // Password sets whether or not to hide the input while the user is typing.
 func (i *Input) Password(password bool) *Input {
 	if password {
@@ -139,6 +147,9 @@ func (i *Input) Blur() tea.Cmd {
 
 // KeyBinds returns the help message for the input field.
 func (i *Input) KeyBinds() []key.Binding {
+	if i.textinput.ShowSuggestions {
+		return []key.Binding{i.keymap.Next, i.keymap.Prev, i.keymap.AcceptSuggestion}
+	}
 	return []key.Binding{i.keymap.Next, i.keymap.Prev}
 }
 
@@ -241,6 +252,7 @@ func (i *Input) runAccessible() error {
 // WithKeyMap sets the keymap on an input field.
 func (i *Input) WithKeyMap(k *KeyMap) Field {
 	i.keymap = &k.Input
+	i.textinput.KeyMap.AcceptSuggestion = i.keymap.AcceptSuggestion
 	return i
 }
 

--- a/keymap.go
+++ b/keymap.go
@@ -16,8 +16,9 @@ type KeyMap struct {
 
 // InputKeyMap is the keybindings for input fields.
 type InputKeyMap struct {
-	Next key.Binding
-	Prev key.Binding
+	AcceptSuggestion key.Binding
+	Next             key.Binding
+	Prev             key.Binding
 }
 
 // TextKeyMap is the keybindings for text fields.
@@ -69,8 +70,9 @@ func NewDefaultKeyMap() *KeyMap {
 	return &KeyMap{
 		Quit: key.NewBinding(key.WithKeys("ctrl+c")),
 		Input: InputKeyMap{
-			Next: key.NewBinding(key.WithKeys("enter", "tab"), key.WithHelp("enter", "next")),
-			Prev: key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "back")),
+			AcceptSuggestion: key.NewBinding(key.WithKeys("ctrl+e"), key.WithHelp("ctrl+e", "complete")),
+			Next:             key.NewBinding(key.WithKeys("enter", "tab"), key.WithHelp("enter", "next")),
+			Prev:             key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "back")),
 		},
 		Text: TextKeyMap{
 			Next:    key.NewBinding(key.WithKeys("tab", "enter"), key.WithHelp("enter", "next")),


### PR DESCRIPTION
Fixes https://github.com/charmbracelet/huh/issues/89

This PR addes autocomplete suggestions for input fields by exposing:

```
Suggestions([]string{"foo", "bar", "baz"})
```

on `field_input`
