### PR TITLE
Scroll Form Inputs

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -30,6 +30,7 @@ type Confirm struct {
 
 	// options
 	width      int
+	height     int
 	accessible bool
 	theme      *Theme
 	keymap     *ConfirmKeyMap
@@ -216,9 +217,15 @@ func (c *Confirm) WithAccessible(accessible bool) Field {
 	return c
 }
 
-// WithWidth sets the accessible mode of the confirm field.
+// WithWidth sets the width of the confirm field.
 func (c *Confirm) WithWidth(width int) Field {
 	c.width = width
+	return c
+}
+
+// WithHeight sets the height of the confirm field.
+func (c *Confirm) WithHeight(height int) Field {
+	c.height = height
 	return c
 }
 

--- a/field_input.go
+++ b/field_input.go
@@ -33,6 +33,7 @@ type Input struct {
 
 	// options
 	width      int
+	height     int
 	accessible bool
 	theme      *Theme
 	keymap     *InputKeyMap
@@ -278,6 +279,12 @@ func (i *Input) WithWidth(width int) Field {
 	if i.inline {
 		i.textinput.Width -= titleWidth
 	}
+	return i
+}
+
+// WithHeight sets the height of the input field.
+func (i *Input) WithHeight(height int) Field {
+	i.height = height
 	return i
 }
 

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -490,6 +490,11 @@ func (m *MultiSelect[T]) WithWidth(width int) Field {
 	return m
 }
 
+// WithHeight sets the height of the multi-select field.
+func (m *MultiSelect[T]) WithHeight(height int) Field {
+	return m.Height(height)
+}
+
 // GetKey returns the multi-select's key.
 func (m *MultiSelect[T]) GetKey() string {
 	return m.key

--- a/field_note.go
+++ b/field_note.go
@@ -20,6 +20,7 @@ type Note struct {
 
 	// options
 	width      int
+	height     int
 	accessible bool
 	theme      *Theme
 	keymap     *NoteKeyMap
@@ -162,6 +163,12 @@ func (n *Note) WithAccessible(accessible bool) Field {
 // WithWidth sets the width of the note field.
 func (n *Note) WithWidth(width int) Field {
 	n.width = width
+	return n
+}
+
+// WithHeight sets the height of the note field.
+func (n *Note) WithHeight(height int) Field {
+	n.height = height
 	return n
 }
 

--- a/field_select.go
+++ b/field_select.go
@@ -426,6 +426,11 @@ func (s *Select[T]) WithWidth(width int) Field {
 	return s
 }
 
+// WithHeight sets the height of the select field.
+func (s *Select[T]) WithHeight(height int) Field {
+	return s.Height(height)
+}
+
 // GetKey returns the key of the field.
 func (s *Select[T]) GetKey() string {
 	return s.key

--- a/field_text.go
+++ b/field_text.go
@@ -305,6 +305,19 @@ func (t *Text) WithWidth(width int) Field {
 	return t
 }
 
+// WithHeight sets the height of the text field.
+func (t *Text) WithHeight(height int) Field {
+	adjust := 0
+	if t.title != "" {
+		adjust++
+	}
+	if t.description != "" {
+		adjust++
+	}
+	t.textarea.SetHeight(height - t.theme.Blurred.Base.GetVerticalFrameSize() - adjust)
+	return t
+}
+
 // GetKey returns the key of the field.
 func (t *Text) GetKey() string {
 	return t.key

--- a/form.go
+++ b/form.go
@@ -55,6 +55,7 @@ type Form struct {
 
 	// options
 	width  int
+	height int
 	theme  *Theme
 	keymap *KeyMap
 }
@@ -74,6 +75,7 @@ func NewForm(groups ...*Group) *Form {
 		theme:     ThemeCharm(),
 		keymap:    NewDefaultKeyMap(),
 		width:     0,
+		height:    0,
 		results:   make(map[string]any),
 	}
 
@@ -82,6 +84,7 @@ func NewForm(groups ...*Group) *Form {
 	f.WithTheme(f.theme)
 	f.WithKeyMap(f.keymap)
 	f.WithWidth(f.width)
+	f.WithHeight(f.height)
 
 	return f
 }
@@ -122,6 +125,9 @@ type Field interface {
 
 	// WithWidth sets the width of a field.
 	WithWidth(int) Field
+
+	// WithHeight sets the height of a field.
+	WithHeight(int) Field
 
 	// GetKey returns the field's key.
 	GetKey() string
@@ -221,6 +227,18 @@ func (f *Form) WithWidth(width int) *Form {
 	f.width = width
 	for _, group := range f.groups {
 		group.WithWidth(width)
+	}
+	return f
+}
+
+// WithHeight sets the height of a form.
+func (f *Form) WithHeight(height int) *Form {
+	if height <= 0 {
+		return f
+	}
+	f.height = height
+	for _, group := range f.groups {
+		group.WithHeight(height)
 	}
 	return f
 }


### PR DESCRIPTION
Allows form height to be specified to allow small forms.

I.e. if a form has a height of 10, the form groups will be scrollable such that
each input is fit on the screen. Inputs will be auto-resized to fit within the
form.
