### PR TITLE
feat: Titlef and Descriptionf

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -94,6 +94,18 @@ func (c *Confirm) Description(description string) *Confirm {
 	return c
 }
 
+// Titlef sets the title of the confirm field.
+func (c *Confirm) Titlef(format string, a ...any) *Confirm {
+	c.title = fmt.Sprintf(format, a...)
+	return c
+}
+
+// Descriptionf sets the description of the confirm field.
+func (c *Confirm) Descriptionf(format string, a ...any) *Confirm {
+	c.description = fmt.Sprintf(format, a...)
+	return c
+}
+
 // Focus focuses the confirm field.
 func (c *Confirm) Focus() tea.Cmd {
 	c.focused = true

--- a/field_input.go
+++ b/field_input.go
@@ -78,6 +78,18 @@ func (i *Input) Description(description string) *Input {
 	return i
 }
 
+// Titlef sets the title of the input field.
+func (i *Input) Titlef(format string, a ...any) *Input {
+	i.title = fmt.Sprintf(format, a...)
+	return i
+}
+
+// Descriptionf sets the description of the input field.
+func (i *Input) Descriptionf(format string, a ...any) *Input {
+	i.description = fmt.Sprintf(format, a...)
+	return i
+}
+
 // Prompt sets the prompt of the input field.
 func (i *Input) Prompt(prompt string) *Input {
 	i.textinput.Prompt = prompt

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -92,6 +92,18 @@ func (m *MultiSelect[T]) Description(description string) *MultiSelect[T] {
 	return m
 }
 
+// Titlef sets the title of the multi-select field.
+func (m *MultiSelect[T]) Titlef(format string, a ...any) *MultiSelect[T] {
+	m.title = fmt.Sprintf(format, a...)
+	return m
+}
+
+// Descriptionf sets the description of the multi-select field.
+func (m *MultiSelect[T]) Descriptionf(format string, a ...any) *MultiSelect[T] {
+	m.description = fmt.Sprintf(format, a...)
+	return m
+}
+
 // Options sets the options of the multi-select field.
 func (m *MultiSelect[T]) Options(options ...Option[T]) *MultiSelect[T] {
 	if len(options) <= 0 {
@@ -376,9 +388,7 @@ func (m *MultiSelect[T]) View() string {
 }
 
 func (m *MultiSelect[T]) printOptions() {
-	var (
-		sb strings.Builder
-	)
+	var sb strings.Builder
 
 	sb.WriteString(m.theme.Focused.Title.Render(m.title))
 	sb.WriteString("\n")

--- a/field_note.go
+++ b/field_note.go
@@ -46,6 +46,18 @@ func (n *Note) Description(description string) *Note {
 	return n
 }
 
+// Titlef sets the title of the note field.
+func (n *Note) Titlef(format string, a ...any) *Note {
+	n.title = fmt.Sprintf(format, a...)
+	return n
+}
+
+// Descriptionf sets the description of the note field.
+func (n *Note) Descriptionf(format string, a ...any) *Note {
+	n.description = fmt.Sprintf(format, a...)
+	return n
+}
+
 // Next sets whether to show the next button.
 func (n *Note) Next(show bool) *Note {
 	n.showNextButton = show

--- a/field_select.go
+++ b/field_select.go
@@ -88,6 +88,18 @@ func (s *Select[T]) Description(description string) *Select[T] {
 	return s
 }
 
+// Titlef sets the title of the select field.
+func (s *Select[T]) Titlef(format string, a ...any) *Select[T] {
+	s.title = fmt.Sprintf(format, a...)
+	return s
+}
+
+// Descriptionf sets the description of the select field.
+func (s *Select[T]) Descriptionf(format string, a ...any) *Select[T] {
+	s.description = fmt.Sprintf(format, a...)
+	return s
+}
+
 // Options sets the options of the select field.
 func (s *Select[T]) Options(options ...Option[T]) *Select[T] {
 	if len(options) <= 0 {

--- a/field_text.go
+++ b/field_text.go
@@ -83,15 +83,27 @@ func (t *Text) Title(title string) *Text {
 	return t
 }
 
-// Lines sets the number of lines to show of the text field.
-func (t *Text) Lines(lines int) *Text {
-	t.textarea.SetHeight(lines)
-	return t
-}
-
 // Description sets the description of the text field.
 func (t *Text) Description(description string) *Text {
 	t.description = description
+	return t
+}
+
+// Titlef sets the title of the text field.
+func (t *Text) Titlef(format string, a ...any) *Text {
+	t.title = fmt.Sprintf(format, a...)
+	return t
+}
+
+// Descriptionf sets the description of the text field.
+func (t *Text) Descriptionf(format string, a ...any) *Text {
+	t.description = fmt.Sprintf(format, a...)
+	return t
+}
+
+// Lines sets the number of lines to show of the text field.
+func (t *Text) Lines(lines int) *Text {
+	t.textarea.SetHeight(lines)
 	return t
 }
 

--- a/group.go
+++ b/group.go
@@ -1,6 +1,7 @@
 package huh
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/help"
@@ -73,6 +74,18 @@ func (g *Group) Title(title string) *Group {
 // Description sets the group's description.
 func (g *Group) Description(description string) *Group {
 	g.description = description
+	return g
+}
+
+// Titlef sets the title of the group field.
+func (g *Group) Titlef(format string, a ...any) *Group {
+	g.title = fmt.Sprintf(format, a...)
+	return g
+}
+
+// Descriptionf sets the description of the group field.
+func (g *Group) Descriptionf(format string, a ...any) *Group {
+	g.description = fmt.Sprintf(format, a...)
 	return g
 }
 

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -58,6 +58,12 @@ func (s *Spinner) Title(title string) *Spinner {
 	return s
 }
 
+// Titlef sets the title of the spinner.
+func (n *Spinner) Titlef(format string, a ...any) *Spinner {
+	n.title = fmt.Sprintf(format, a...)
+	return n
+}
+
 // Action sets the action of the spinner.
 func (s *Spinner) Action(action func()) *Spinner {
 	s.action = action


### PR DESCRIPTION
prevents having to use `[Title|Description](fmt.Sprinf(...))`.