### PR TITLE
fix incorrect documentation for the `WithShowErrors` method

### DIFF
--- a/form.go
+++ b/form.go
@@ -176,7 +176,7 @@ func (f *Form) WithShowHelp(v bool) *Form {
 
 // WithShowErrors sets whether or not the form should show errors.
 //
-// This allows the form groups and field to show the error when the Validate
+// This allows the form groups and fields to show errors when the Validate 
 // function returns an error.
 func (f *Form) WithShowErrors(v bool) *Form {
 	for _, group := range f.groups {

--- a/form.go
+++ b/form.go
@@ -174,10 +174,10 @@ func (f *Form) WithShowHelp(v bool) *Form {
 	return f
 }
 
-// WithShowErrors sets whether or not the form should show help.
+// WithShowErrors sets whether or not the form should show errors.
 //
-// This allows the form groups and field to show what keybindings are available
-// to the user.
+// This allows the form groups and field to show the error when the Validate
+// function returns an error.
 func (f *Form) WithShowErrors(v bool) *Form {
 	for _, group := range f.groups {
 		group.WithShowErrors(v)


### PR DESCRIPTION
currently the documentation for the [`Form.WithShowErrors()` ](https://github.com/charmbracelet/huh/blob/58163e7b5b2ffb7d60176490eda32ee4210b9d40/form.go#L170) is the same as [`Form.WithShowHelp`](https://github.com/charmbracelet/huh/blob/58163e7b5b2ffb7d60176490eda32ee4210b9d40/form.go#L181) , this fixes that.