### PR TITLE
fix: shift+tab would fail if first group is hidden

### DIFF
--- a/examples/hide/main.go
+++ b/examples/hide/main.go
@@ -23,6 +23,7 @@ func main() {
 		).WithHideFunc(func() bool {
 			return !isAllergic
 		}),
+		huh.NewGroup(huh.NewNote().Title("Invisible")).WithHide(true),
 	).Run()
 
 	if isAllergic {


### PR DESCRIPTION
the previous version was changing the page to a potentially hidden page, this PR fixes it, and covers it with tests.