### PR TITLE
Skippable Fields

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -59,6 +59,11 @@ func (c *Confirm) Error() error {
 	return c.err
 }
 
+// Skip returns whether the confirm should be skipped or should be blocking.
+func (*Confirm) Skip() bool {
+	return false
+}
+
 // Affirmative sets the affirmative value of the confirm field.
 func (c *Confirm) Affirmative(affirmative string) *Confirm {
 	c.affirmative = affirmative

--- a/field_input.go
+++ b/field_input.go
@@ -132,6 +132,11 @@ func (i *Input) Error() error {
 	return i.err
 }
 
+// Skip returns whether the input should be skipped or should be blocking.
+func (*Input) Skip() bool {
+	return false
+}
+
 // Focus focuses the input field.
 func (i *Input) Focus() tea.Cmd {
 	i.focused = true

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -144,6 +144,11 @@ func (m *MultiSelect[T]) Error() error {
 	return m.err
 }
 
+// Skip returns whether the multiselect should be skipped or should be blocking.
+func (*MultiSelect[T]) Skip() bool {
+	return false
+}
+
 // Focus focuses the multi-select field.
 func (m *MultiSelect[T]) Focus() tea.Cmd {
 	m.focused = true

--- a/field_note.go
+++ b/field_note.go
@@ -19,6 +19,7 @@ type Note struct {
 	focused        bool
 
 	// options
+	skip       bool
 	width      int
 	height     int
 	accessible bool
@@ -31,6 +32,7 @@ func NewNote() *Note {
 	return &Note{
 		showNextButton: false,
 		theme:          ThemeCharm(),
+		skip:           true,
 	}
 }
 
@@ -67,6 +69,11 @@ func (n *Note) Blur() tea.Cmd {
 // Error returns the error of the note field.
 func (n *Note) Error() error {
 	return nil
+}
+
+// Skip returns whether the note should be skipped or should be blocking.
+func (n *Note) Skip() bool {
+	return n.skip
 }
 
 // KeyBinds returns the help message for the note field.
@@ -175,6 +182,9 @@ func (n *Note) WithHeight(height int) Field {
 
 // WithPosition sets the position information of the note field.
 func (n *Note) WithPosition(p FieldPosition) Field {
+	if p.FieldCount == 1 {
+		n.skip = false
+	}
 	n.keymap.Prev.SetEnabled(!p.IsFirst())
 	n.keymap.Next.SetEnabled(!p.IsLast())
 	n.keymap.Submit.SetEnabled(p.IsLast())

--- a/field_select.go
+++ b/field_select.go
@@ -130,6 +130,11 @@ func (s *Select[T]) Error() error {
 	return s.err
 }
 
+// Skip returns whether the select should be skipped or should be blocking.
+func (*Select[T]) Skip() bool {
+	return false
+}
+
 // Focus focuses the select field.
 func (s *Select[T]) Focus() tea.Cmd {
 	s.focused = true

--- a/field_text.go
+++ b/field_text.go
@@ -149,6 +149,11 @@ func (t *Text) Error() error {
 	return t.err
 }
 
+// Skip returns whether the textarea should be skipped or should be blocking.
+func (*Text) Skip() bool {
+	return false
+}
+
 // Focus focuses the text field.
 func (t *Text) Focus() tea.Cmd {
 	t.focused = true

--- a/form.go
+++ b/form.go
@@ -112,6 +112,9 @@ type Field interface {
 	// Run runs the field individually.
 	Run() error
 
+	// Skip returns whether this input should be skipped or not.
+	Skip() bool
+
 	// KeyBinds returns help keybindings.
 	KeyBinds() []key.Binding
 
@@ -454,6 +457,7 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return submit()
 			}
 		}
+		return f, f.groups[f.paginator.Page].Init()
 
 	case prevGroupMsg:
 		if len(group.Errors()) > 0 {
@@ -470,6 +474,8 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				break
 			}
 		}
+
+		return f, f.groups[f.paginator.Page].Init()
 	}
 
 	m, cmd := group.Update(msg)

--- a/group.go
+++ b/group.go
@@ -177,31 +177,51 @@ func prevField() tea.Msg {
 
 // Init initializes the group.
 func (g *Group) Init() tea.Cmd {
-	cmds := make([]tea.Cmd, len(g.fields)+1)
-	for i, field := range g.fields {
-		cmds[i] = field.Init()
+	var cmds []tea.Cmd
+
+	if g.fields[g.paginator.Page].Skip() {
+		if g.paginator.OnLastPage() {
+			cmds = append(cmds, g.prevField()...)
+		} else if g.paginator.Page == 0 {
+			cmds = append(cmds, g.nextField()...)
+		}
+		return tea.Batch(cmds...)
 	}
+
 	cmd := g.fields[g.paginator.Page].Focus()
 	cmds = append(cmds, cmd)
 	return tea.Batch(cmds...)
 }
 
-// setCurrent sets the current field.
-func (g *Group) setCurrent(current int) tea.Cmd {
-	var (
-		cmds []tea.Cmd
-		cmd  tea.Cmd
-	)
+// nextField moves to the next field.
+func (g *Group) nextField() []tea.Cmd {
+	blurCmd := g.fields[g.paginator.Page].Blur()
+	if g.paginator.OnLastPage() {
+		return []tea.Cmd{blurCmd, nextGroup}
+	}
+	g.paginator.NextPage()
+	if g.fields[g.paginator.Page].Skip() {
+		g.paginator.NextPage()
+	}
+	focusCmd := g.fields[g.paginator.Page].Focus()
+	return []tea.Cmd{blurCmd, focusCmd}
+}
 
-	cmd = g.fields[g.paginator.Page].Blur()
-	cmds = append(cmds, cmd)
-
-	g.paginator.Page = clamp(current, 0, len(g.fields)-1)
-
-	cmd = g.fields[g.paginator.Page].Focus()
-	cmds = append(cmds, cmd)
-
-	return tea.Batch(cmds...)
+// prevField moves to the previous field.
+func (g *Group) prevField() []tea.Cmd {
+	blurCmd := g.fields[g.paginator.Page].Blur()
+	if g.paginator.Page <= 0 {
+		return []tea.Cmd{blurCmd, prevGroup}
+	}
+	g.paginator.PrevPage()
+	if g.fields[g.paginator.Page].Skip() {
+		if g.paginator.Page <= 0 {
+			return []tea.Cmd{blurCmd, prevGroup}
+		}
+		g.paginator.PrevPage()
+	}
+	focusCmd := g.fields[g.paginator.Page].Focus()
+	return []tea.Cmd{blurCmd, focusCmd}
 }
 
 // Update updates the group.
@@ -215,38 +235,20 @@ func (g *Group) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg.(type) {
 	case nextFieldMsg:
-		current := g.paginator.Page
-		cmd = g.setCurrent(current + 1)
-
-		if current >= g.paginator.TotalPages-1 {
-			cmds = append(cmds, nextGroup)
-			break
-		}
-
+		cmds = append(cmds, g.nextField()...)
 		offset := 0
-		for i := 0; i <= current; i++ {
+		for i := 0; i <= g.paginator.Page; i++ {
 			offset += lipgloss.Height(g.fields[i].View()) + 1
 		}
 		g.viewport.SetYOffset(offset)
-
-		cmds = append(cmds, cmd)
 
 	case prevFieldMsg:
-		current := g.paginator.Page
-		cmd = g.setCurrent(current - 1)
-
-		if current == 0 {
-			cmds = append(cmds, prevGroup)
-			break
-		}
-
+		cmds = append(cmds, g.prevField()...)
 		offset := 0
-		for i := 0; i < current-1; i++ {
+		for i := 0; i < g.paginator.Page; i++ {
 			offset += lipgloss.Height(g.fields[i].View()) + 1
 		}
 		g.viewport.SetYOffset(offset)
-
-		cmds = append(cmds, cmd)
 	}
 
 	return g, tea.Batch(cmds...)

--- a/group.go
+++ b/group.go
@@ -200,7 +200,10 @@ func (g *Group) nextField() []tea.Cmd {
 		return []tea.Cmd{blurCmd, nextGroup}
 	}
 	g.paginator.NextPage()
-	if g.fields[g.paginator.Page].Skip() {
+	for g.fields[g.paginator.Page].Skip() {
+		if g.paginator.OnLastPage() {
+			return []tea.Cmd{blurCmd, nextGroup}
+		}
 		g.paginator.NextPage()
 	}
 	focusCmd := g.fields[g.paginator.Page].Focus()
@@ -214,7 +217,7 @@ func (g *Group) prevField() []tea.Cmd {
 		return []tea.Cmd{blurCmd, prevGroup}
 	}
 	g.paginator.PrevPage()
-	if g.fields[g.paginator.Page].Skip() {
+	for g.fields[g.paginator.Page].Skip() {
 		if g.paginator.Page <= 0 {
 			return []tea.Cmd{blurCmd, prevGroup}
 		}

--- a/huh_test.go
+++ b/huh_test.go
@@ -634,6 +634,54 @@ func TestDynamicHelp(t *testing.T) {
 	}
 }
 
+func TestSkip(t *testing.T) {
+	f := NewForm(
+		NewGroup(
+			NewInput().Title("First"),
+			NewNote().Title("Skipped"),
+			NewNote().Title("Skipped"),
+			NewInput().Title("Second"),
+		),
+	).WithWidth(25)
+
+	f = batchUpdate(f, f.Init()).(*Form)
+	view := f.View()
+
+	if !strings.Contains(view, "┃ First") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected first field to be focused")
+	}
+
+	// next field should skip both of the notes and proceed to the last input.
+	f.Update(nextField())
+	view = f.View()
+
+	if strings.Contains(view, "┃ First") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected first field to be blurred")
+	}
+
+	if !strings.Contains(view, "┃ Second") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected second field to be focused")
+	}
+
+	// previous field should skip both of the notes and focus the first input.
+	f.Update(prevField())
+	view = f.View()
+
+	if strings.Contains(view, "┃ Second") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected second field to be blurred")
+	}
+
+	if !strings.Contains(view, "┃ First") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected first field to be focused")
+	}
+
+}
+
 func batchUpdate(m tea.Model, cmd tea.Cmd) tea.Model {
 	if cmd == nil {
 		return m


### PR DESCRIPTION
This PR allows fields to be declared as skippable as in they will not be
interactible by the users.

Currently, this is only used by the `Note`s field but can be expanded to
dynamically Skip other fields as well such as skip if the field was passed in
through a command line argument, for example.
