### PR TITLE
Allow theme to be set only once

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -219,6 +219,9 @@ func (c *Confirm) String() string {
 
 // WithTheme sets the theme of the confirm field.
 func (c *Confirm) WithTheme(theme *Theme) Field {
+	if c.theme != nil {
+		return c
+	}
 	c.theme = theme
 	return c
 }

--- a/field_input.go
+++ b/field_input.go
@@ -270,6 +270,9 @@ func (i *Input) WithAccessible(accessible bool) Field {
 
 // WithTheme sets the theme of the input field.
 func (i *Input) WithTheme(theme *Theme) Field {
+	if i.theme != nil {
+		return i
+	}
 	i.theme = theme
 	return i
 }

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -468,6 +468,9 @@ func (m *MultiSelect[T]) runAccessible() error {
 
 // WithTheme sets the theme of the multi-select field.
 func (m *MultiSelect[T]) WithTheme(theme *Theme) Field {
+	if m.theme != nil {
+		return m
+	}
 	m.theme = theme
 	m.filter.Cursor.Style = m.theme.Focused.TextInput.Cursor
 	m.filter.PromptStyle = m.theme.Focused.TextInput.Prompt

--- a/field_note.go
+++ b/field_note.go
@@ -152,6 +152,9 @@ func (n *Note) runAccessible() error {
 
 // WithTheme sets the theme on a note field.
 func (n *Note) WithTheme(theme *Theme) Field {
+	if n.theme != nil {
+		return n
+	}
 	n.theme = theme
 	return n
 }

--- a/field_select.go
+++ b/field_select.go
@@ -402,6 +402,9 @@ func (s *Select[T]) runAccessible() error {
 
 // WithTheme sets the theme of the select field.
 func (s *Select[T]) WithTheme(theme *Theme) Field {
+	if s.theme != nil {
+		return s
+	}
 	s.theme = theme
 	s.filter.Cursor.Style = s.theme.Focused.TextInput.Cursor
 	s.filter.PromptStyle = s.theme.Focused.TextInput.Prompt

--- a/field_text.go
+++ b/field_text.go
@@ -286,6 +286,9 @@ func (t *Text) runAccessible() error {
 
 // WithTheme sets the theme on a text field.
 func (t *Text) WithTheme(theme *Theme) Field {
+	if t.theme != nil {
+		return t
+	}
 	t.theme = theme
 	return t
 }


### PR DESCRIPTION
This PR makes it so that themes can be applied on individual inputs, groups, or forms.

How it works is that it simply sets the theme only if it is not already set.
This means the theme that was set first will take precendence and not be
overridden as how it currently is being overridden.

That means, if a user creates a `field.WithTheme` that will be the permanent
theme of the field, if the user creates a `group.WithTheme` that will be the
theme of each field in the group (unless it already has a theme applied by the
field individually), and so on...
