### PR TITLE
fix: charlimit of text field in Accessible mode

### DIFF
--- a/field_text.go
+++ b/field_text.go
@@ -292,7 +292,7 @@ func (t *Text) runAccessible() error {
 		}
 
 		if len(input) > t.textarea.CharLimit {
-			return fmt.Errorf("the input text length should not exceed %d characters", t.textarea.CharLimit)
+			return fmt.Errorf("Input cannot exceed %d characters", t.textarea.CharLimit)
 		}
 		return nil
 	})

--- a/field_text.go
+++ b/field_text.go
@@ -285,7 +285,13 @@ func (t *Text) Run() error {
 func (t *Text) runAccessible() error {
 	fmt.Println(t.theme.Blurred.Base.Render(t.theme.Focused.Title.Render(t.title)))
 	fmt.Println()
-	*t.value = accessibility.PromptString("Input: ", t.validate)
+	*t.value = accessibility.PromptString("Input: ", func(input string) error {
+		t.validate(input)
+		if len(input) > t.textarea.CharLimit {
+			return fmt.Errorf("\n The input text length should not exceed %d characters. \n", t.textarea.CharLimit)
+		}
+		return nil
+	})
 	fmt.Println()
 	return nil
 }

--- a/field_text.go
+++ b/field_text.go
@@ -286,7 +286,11 @@ func (t *Text) runAccessible() error {
 	fmt.Println(t.theme.Blurred.Base.Render(t.theme.Focused.Title.Render(t.title)))
 	fmt.Println()
 	*t.value = accessibility.PromptString("Input: ", func(input string) error {
-		t.validate(input)
+		if err := t.validate(input); err != nil {
+			// Handle the error from t.validate, return it
+			return err
+		}
+
 		if len(input) > t.textarea.CharLimit {
 			return fmt.Errorf("the input text length should not exceed %d characters", t.textarea.CharLimit)
 		}

--- a/field_text.go
+++ b/field_text.go
@@ -288,7 +288,7 @@ func (t *Text) runAccessible() error {
 	*t.value = accessibility.PromptString("Input: ", func(input string) error {
 		t.validate(input)
 		if len(input) > t.textarea.CharLimit {
-			return fmt.Errorf("\n The input text length should not exceed %d characters. \n", t.textarea.CharLimit)
+			return fmt.Errorf("the input text length should not exceed %d characters", t.textarea.CharLimit)
 		}
 		return nil
 	})


### PR DESCRIPTION
This PR fixes issue discussed in #114 .

Now error will be shown if `charLimit` hits:
<img width="601" alt="image" src="https://github.com/charmbracelet/huh/assets/155895067/bb3291c2-c615-4226-b034-be8425ac72bd">
