### PR TITLE
feat: add GetFocused to field_input

### DIFF
--- a/field_input.go
+++ b/field_input.go
@@ -342,3 +342,8 @@ func (i *Input) GetKey() string {
 func (i *Input) GetValue() any {
 	return *i.value
 }
+
+// GetFocused returns if the input is focused.
+func (i *Input) GetFocused() bool {
+	return i.focused
+}


### PR DESCRIPTION
My use case is that I have a field that I'd like to update suggestions for based on what the user has input. When the user starts typing, a search endpoint is hit with the current value of the field as the query parameter and the suggestions is updated based off the returned search.

So basically, in my Update I want to check if the field is focused and then if a new key was pressed to hit the endpoint and update the suggestions.