### PR TITLE
Themes should be applied as specified

### DIFF
--- a/field_filepicker.go
+++ b/field_filepicker.go
@@ -293,7 +293,7 @@ func (f *FilePicker) WithTheme(theme *Theme) Field {
 
 	f.theme = theme
 
-	// TODO: add specific themes
+	// XXX: add specific themes
 	f.picker.Styles = filepicker.Styles{
 		DisabledCursor:   lipgloss.Style{},
 		Cursor:           theme.Focused.TextInput.Prompt,

--- a/field_filepicker.go
+++ b/field_filepicker.go
@@ -55,7 +55,6 @@ func NewFilePicker() *FilePicker {
 		value:    new(string),
 		validate: func(string) error { return nil },
 		picker:   fp,
-		theme:    ThemeCharm(),
 	}
 }
 
@@ -288,6 +287,10 @@ func (f *FilePicker) runAccessible() error {
 
 // WithTheme sets the theme of the file field.
 func (f *FilePicker) WithTheme(theme *Theme) Field {
+	if f.theme != nil {
+		return f
+	}
+
 	f.theme = theme
 
 	// TODO: add specific themes

--- a/field_input.go
+++ b/field_input.go
@@ -47,7 +47,6 @@ func NewInput() *Input {
 		value:     new(string),
 		textinput: input,
 		validate:  func(string) error { return nil },
-		theme:     ThemeCharm(),
 	}
 
 	return i

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -55,7 +55,6 @@ func NewMultiSelect[T comparable]() *MultiSelect[T] {
 		validate:  func([]T) error { return nil },
 		filtering: false,
 		filter:    filter,
-		theme:     ThemeCharm(),
 	}
 }
 

--- a/field_note.go
+++ b/field_note.go
@@ -31,7 +31,6 @@ type Note struct {
 func NewNote() *Note {
 	return &Note{
 		showNextButton: false,
-		theme:          ThemeCharm(),
 		skip:           true,
 	}
 }

--- a/field_select.go
+++ b/field_select.go
@@ -54,7 +54,6 @@ func NewSelect[T comparable]() *Select[T] {
 		validate:  func(T) error { return nil },
 		filtering: false,
 		filter:    filter,
-		theme:     ThemeCharm(),
 	}
 }
 

--- a/field_text.go
+++ b/field_text.go
@@ -58,7 +58,6 @@ func NewText() *Text {
 		editorCmd:       editorCmd,
 		editorArgs:      editorArgs,
 		editorExtension: "md",
-		theme:           ThemeCharm(),
 	}
 
 	return t

--- a/form.go
+++ b/form.go
@@ -86,7 +86,6 @@ func NewForm(groups ...*Group) *Form {
 
 	// NB: If dynamic forms come into play this will need to be applied when
 	// groups and fields are added.
-	f.WithTheme(f.theme)
 	f.WithKeyMap(f.keymap)
 	f.WithWidth(f.width)
 	f.WithHeight(f.height)
@@ -541,6 +540,9 @@ func (f *Form) View() string {
 
 // Run runs the form.
 func (f *Form) Run() error {
+	// Apply the default theme to any unstyled groups / fields.
+	f.WithTheme(ThemeCharm())
+
 	f.submitCmd = tea.Quit
 	f.cancelCmd = tea.Quit
 


### PR DESCRIPTION
This applies themes as specified, in order of specificity.

Themes will be applied to Fields, then Groups, then Forms. This way different fields / groups can have different themes.
