### PR TITLE
feat: set filtering state of select

### DIFF
--- a/field_select.go
+++ b/field_select.go
@@ -87,6 +87,13 @@ func (s *Select[T]) Title(title string) *Select[T] {
 	return s
 }
 
+// Filtering sets the filtering state of the select field.
+func (s *Select[T]) Filtering(filtering bool) *Select[T] {
+	s.filtering = filtering
+	s.filter.Focus()
+	return s
+}
+
 // Description sets the description of the select field.
 func (s *Select[T]) Description(description string) *Select[T] {
 	s.description = description


### PR DESCRIPTION
This PR adresse the following issue #173 

It allows allows use the select where the filter mode is activated when Run starts.

Thanks for telling me to also update the focus @maaslalani !

I have the following results with this code (readme example adapted a little).
```go
package main

import (
	"fmt"

	"github.com/charmbracelet/huh"
)

func main() {
	var country string
	s := huh.NewSelect[string]().
		Title("Pick a country.").
		Filtering(true).
		Options(
			huh.NewOption("United States", "US"),
			huh.NewOption("Germany", "DE"),
			huh.NewOption("Brazil", "BR"),
			huh.NewOption("Canada", "CA"),
		).
		Value(&country)

	huh.NewForm(huh.NewGroup(s)).Run()

	fmt.Println("You chose ", country)
}

```
![demo](https://github.com/charmbracelet/huh/assets/43468407/b6579dbd-768a-43a7-92aa-8f4127fd95c5)
