### PR TITLE
feat: disabled options

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -255,7 +255,8 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keymap.Toggle):
 			for i, option := range m.options {
 				if option.Key == m.filteredOptions[m.cursor].Key {
-					if !m.options[m.cursor].selected && m.limit > 0 && m.numSelected() >= m.limit {
+					if !m.options[m.cursor].selected && m.limit > 0 && m.numSelected() >= m.limit ||
+						m.options[m.cursor].disabled {
 						break
 					}
 					selected := m.options[i].selected
@@ -384,10 +385,18 @@ func (m *MultiSelect[T]) choicesView() string {
 
 		if m.filteredOptions[i].selected {
 			sb.WriteString(styles.SelectedPrefix.String())
-			sb.WriteString(styles.SelectedOption.Render(option.Key))
+			if option.disabled {
+				sb.WriteString(styles.DisabledOption.Render(option.Key))
+			} else {
+				sb.WriteString(styles.SelectedOption.Render(option.Key))
+			}
 		} else {
 			sb.WriteString(styles.UnselectedPrefix.String())
-			sb.WriteString(styles.UnselectedOption.Render(option.Key))
+			if option.disabled {
+				sb.WriteString(styles.DisabledOption.Render(option.Key))
+			} else {
+				sb.WriteString(styles.UnselectedOption.Render(option.Key))
+			}
 		}
 		if i < len(m.options)-1 {
 			sb.WriteString("\n")

--- a/field_select.go
+++ b/field_select.go
@@ -270,7 +270,7 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				s.viewport.LineDown(1)
 			}
 		case key.Matches(msg, s.keymap.Prev):
-			if s.selected >= len(s.filteredOptions) {
+			if s.selected >= len(s.filteredOptions) || s.filteredOptions[s.selected].disabled {
 				break
 			}
 			value := s.filteredOptions[s.selected].Value
@@ -281,7 +281,7 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			*s.value = value
 			return s, PrevField
 		case key.Matches(msg, s.keymap.Next, s.keymap.Submit):
-			if s.selected >= len(s.filteredOptions) {
+			if s.selected >= len(s.filteredOptions) || s.filteredOptions[s.selected].disabled {
 				break
 			}
 			value := s.filteredOptions[s.selected].Value
@@ -389,9 +389,17 @@ func (s *Select[T]) choicesView() string {
 
 	for i, option := range s.filteredOptions {
 		if s.selected == i {
-			sb.WriteString(c + styles.SelectedOption.Render(option.Key))
+			if option.disabled {
+				sb.WriteString(c + styles.DisabledOption.Render(option.Key))
+			} else {
+				sb.WriteString(c + styles.SelectedOption.Render(option.Key))
+			}
 		} else {
-			sb.WriteString(strings.Repeat(" ", lipgloss.Width(c)) + styles.Option.Render(option.Key))
+			if option.disabled {
+				sb.WriteString(strings.Repeat(" ", lipgloss.Width(c)) + styles.DisabledOption.Render(option.Key))
+			} else {
+				sb.WriteString(strings.Repeat(" ", lipgloss.Width(c)) + styles.Option.Render(option.Key))
+			}
 		}
 		if i < len(s.options)-1 {
 			sb.WriteString("\n")

--- a/option.go
+++ b/option.go
@@ -7,6 +7,7 @@ type Option[T comparable] struct {
 	Key      string
 	Value    T
 	selected bool
+	disabled bool
 }
 
 // NewOptions returns new options from a list of values.
@@ -29,6 +30,12 @@ func NewOption[T comparable](key string, value T) Option[T] {
 // Selected sets whether the option is currently selected.
 func (o Option[T]) Selected(selected bool) Option[T] {
 	o.selected = selected
+	return o
+}
+
+// Disabled sets whether the option is disabled.
+func (o Option[T]) Disabled(disabled bool) Option[T] {
+	o.disabled = disabled
 	return o
 }
 

--- a/theme.go
+++ b/theme.go
@@ -50,6 +50,7 @@ type FieldStyles struct {
 	Option         lipgloss.Style // Select options
 	NextIndicator  lipgloss.Style
 	PrevIndicator  lipgloss.Style
+	DisabledOption lipgloss.Style
 
 	// FilePicker styles.
 	Directory lipgloss.Style
@@ -109,6 +110,7 @@ func (f FieldStyles) copy() FieldStyles {
 		File:                f.File.Copy(),
 		MultiSelectSelector: f.MultiSelectSelector.Copy(),
 		SelectedOption:      f.SelectedOption.Copy(),
+		DisabledOption:      f.DisabledOption.Copy(),
 		SelectedPrefix:      f.SelectedPrefix.Copy(),
 		UnselectedOption:    f.UnselectedOption.Copy(),
 		UnselectedPrefix:    f.UnselectedPrefix.Copy(),
@@ -194,6 +196,7 @@ func ThemeCharm() *Theme {
 		fuchsia  = lipgloss.Color("#F780E2")
 		green    = lipgloss.AdaptiveColor{Light: "#02BA84", Dark: "#02BF87"}
 		red      = lipgloss.AdaptiveColor{Light: "#FF4672", Dark: "#ED567A"}
+		comment  = lipgloss.AdaptiveColor{Light: "", Dark: "243"}
 	)
 
 	f := &t.Focused
@@ -201,7 +204,7 @@ func ThemeCharm() *Theme {
 	f.Title.Foreground(indigo).Bold(true)
 	f.NoteTitle.Foreground(indigo).Bold(true).MarginBottom(1)
 	f.Directory.Foreground(indigo)
-	f.Description.Foreground(lipgloss.AdaptiveColor{Light: "", Dark: "243"})
+	f.Description.Foreground(comment)
 	f.ErrorIndicator.Foreground(red)
 	f.ErrorMessage.Foreground(red)
 	f.SelectSelector.Foreground(fuchsia)
@@ -210,6 +213,7 @@ func ThemeCharm() *Theme {
 	f.Option.Foreground(normalFg)
 	f.MultiSelectSelector.Foreground(fuchsia)
 	f.SelectedOption.Foreground(green)
+	f.DisabledOption.Foreground(comment)
 	f.SelectedPrefix = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#02CF92", Dark: "#02A877"}).SetString("✓ ")
 	f.UnselectedPrefix = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "", Dark: "243"}).SetString("• ")
 	f.UnselectedOption.Foreground(normalFg)
@@ -259,6 +263,7 @@ func ThemeDracula() *Theme {
 	f.Option.Foreground(foreground)
 	f.MultiSelectSelector.Foreground(yellow)
 	f.SelectedOption.Foreground(green)
+	f.DisabledOption.Foreground(comment)
 	f.SelectedPrefix.Foreground(green)
 	f.UnselectedOption.Foreground(foreground)
 	f.UnselectedPrefix.Foreground(comment)
@@ -295,6 +300,7 @@ func ThemeBase16() *Theme {
 	f.Option.Foreground(lipgloss.Color("7"))
 	f.MultiSelectSelector.Foreground(lipgloss.Color("3"))
 	f.SelectedOption.Foreground(lipgloss.Color("2"))
+	f.DisabledOption.Foreground(lipgloss.Color("8"))
 	f.SelectedPrefix.Foreground(lipgloss.Color("2"))
 	f.UnselectedOption.Foreground(lipgloss.Color("7"))
 	f.FocusedButton.Foreground(lipgloss.Color("7")).Background(lipgloss.Color("5"))
@@ -350,6 +356,7 @@ func ThemeCatppuccin() *Theme {
 	f.Option.Foreground(text)
 	f.MultiSelectSelector.Foreground(pink)
 	f.SelectedOption.Foreground(green)
+	f.DisabledOption.Foreground(subtext0)
 	f.SelectedPrefix.Foreground(green)
 	f.UnselectedPrefix.Foreground(text)
 	f.UnselectedOption.Foreground(text)


### PR DESCRIPTION
summary:
- add disabled options (used in select and multi-select components)
- these options will be rendered (including the filtered list), but un-toggle-able
  - select: you can't select that option
  - multi-select: you can't toggle that option 
- color-wise, they use the same color description does

(i'm not sure how the gif is best generated for the readme)

example usage:
```go
huh.NewOption("Charm Sauce (sorry, we've run out!)", "Charm Sauce").Disabled(true),
```

example form question:
```
Toppings:
> [ ] Lettuce
  [ ] Tomatoes
  [ ] Charm Sauce (sorry, we've run out!)
  [ ] Nutella
```

example GIF:
![Untitled](https://github.com/charmbracelet/huh/assets/5616556/b8798d8c-1642-4898-960b-74046a522450)

closes #77 