### PR TITLE
Set themes on fields

### DIFF
--- a/examples/burger/main.go
+++ b/examples/burger/main.go
@@ -74,8 +74,7 @@ func main() {
 					}
 					return nil
 				}).
-				Value(&order.Burger.Type).
-				WithTheme(huh.ThemeCatppuccin()),
+				Value(&order.Burger.Type),
 
 			huh.NewMultiSelect[string]().
 				Title("Toppings").
@@ -98,7 +97,7 @@ func main() {
 				Value(&order.Burger.Toppings).
 				Filterable(true).
 				Limit(4),
-		).WithTheme(huh.ThemeDracula()),
+		),
 
 		// Prompt for toppings and special instructions.
 		// The customer can ask for up to 4 toppings.
@@ -110,8 +109,7 @@ func main() {
 					huh.NewOption("Medium", Medium),
 					huh.NewOption("Hot", Hot),
 				).
-				Value(&order.Burger.Spice).
-				WithTheme(huh.ThemeDracula()),
+				Value(&order.Burger.Spice),
 
 			huh.NewSelect[string]().
 				Options(huh.NewOptions("Fries", "Disco Fries", "R&B Fries", "Carrots")...).
@@ -148,7 +146,7 @@ func main() {
 				Affirmative("Yes!").
 				Negative("No."),
 		),
-	).WithAccessible(accessible).WithTheme(huh.ThemeBase())
+	).WithAccessible(accessible)
 
 	err := form.Run()
 

--- a/examples/burger/main.go
+++ b/examples/burger/main.go
@@ -74,7 +74,8 @@ func main() {
 					}
 					return nil
 				}).
-				Value(&order.Burger.Type),
+				Value(&order.Burger.Type).
+				WithTheme(huh.ThemeCatppuccin()),
 
 			huh.NewMultiSelect[string]().
 				Title("Toppings").
@@ -97,7 +98,7 @@ func main() {
 				Value(&order.Burger.Toppings).
 				Filterable(true).
 				Limit(4),
-		),
+		).WithTheme(huh.ThemeDracula()),
 
 		// Prompt for toppings and special instructions.
 		// The customer can ask for up to 4 toppings.
@@ -109,7 +110,8 @@ func main() {
 					huh.NewOption("Medium", Medium),
 					huh.NewOption("Hot", Hot),
 				).
-				Value(&order.Burger.Spice),
+				Value(&order.Burger.Spice).
+				WithTheme(huh.ThemeDracula()),
 
 			huh.NewSelect[string]().
 				Options(huh.NewOptions("Fries", "Disco Fries", "R&B Fries", "Carrots")...).
@@ -146,7 +148,7 @@ func main() {
 				Affirmative("Yes!").
 				Negative("No."),
 		),
-	).WithAccessible(accessible)
+	).WithAccessible(accessible).WithTheme(huh.ThemeBase())
 
 	err := form.Run()
 

--- a/field_confirm.go
+++ b/field_confirm.go
@@ -44,7 +44,6 @@ func NewConfirm() *Confirm {
 		affirmative: "Yes",
 		negative:    "No",
 		validate:    func(bool) error { return nil },
-		theme:       ThemeCharm(),
 	}
 }
 
@@ -158,12 +157,19 @@ func (c *Confirm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return c, tea.Batch(cmds...)
 }
 
+func (c *Confirm) activeStyles() *FieldStyles {
+	if c.theme == nil {
+		return &ThemeCharm().Blurred
+	}
+	if c.focused {
+		return &c.theme.Focused
+	}
+	return &c.theme.Blurred
+}
+
 // View renders the confirm field.
 func (c *Confirm) View() string {
-	styles := c.theme.Blurred
-	if c.focused {
-		styles = c.theme.Focused
-	}
+	styles := c.activeStyles()
 
 	var sb strings.Builder
 	sb.WriteString(styles.Title.Render(c.title))
@@ -211,10 +217,11 @@ func (c *Confirm) Run() error {
 
 // runAccessible runs the confirm field in accessible mode.
 func (c *Confirm) runAccessible() error {
-	fmt.Println(c.theme.Blurred.Base.Render(c.theme.Focused.Title.Render(c.title)))
+	styles := c.activeStyles()
+	fmt.Println(styles.Title.Render(c.title))
 	fmt.Println()
 	*c.value = accessibility.PromptBool()
-	fmt.Println(c.theme.Focused.SelectedOption.Render("Chose: "+c.String()) + "\n")
+	fmt.Println(styles.SelectedOption.Render("Chose: "+c.String()) + "\n")
 	return nil
 }
 
@@ -227,6 +234,9 @@ func (c *Confirm) String() string {
 
 // WithTheme sets the theme of the confirm field.
 func (c *Confirm) WithTheme(theme *Theme) Field {
+	if c.theme != nil {
+		return c
+	}
 	c.theme = theme
 	return c
 }

--- a/field_confirm.go
+++ b/field_confirm.go
@@ -158,13 +158,14 @@ func (c *Confirm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (c *Confirm) activeStyles() *FieldStyles {
-	if c.theme == nil {
-		return &ThemeCharm().Blurred
+	theme := c.theme
+	if theme == nil {
+		theme = ThemeCharm()
 	}
 	if c.focused {
-		return &c.theme.Focused
+		return &theme.Focused
 	}
-	return &c.theme.Blurred
+	return &theme.Blurred
 }
 
 // View renders the confirm field.

--- a/field_filepicker.go
+++ b/field_filepicker.go
@@ -235,13 +235,14 @@ func (f *FilePicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (f *FilePicker) activeStyles() *FieldStyles {
-	if f.theme == nil {
-		return &ThemeCharm().Blurred
+	theme := f.theme
+	if theme == nil {
+		theme = ThemeCharm()
 	}
 	if f.focused {
-		return &f.theme.Focused
+		return &theme.Focused
 	}
-	return &f.theme.Blurred
+	return &theme.Blurred
 }
 
 // View renders the file field.

--- a/field_input.go
+++ b/field_input.go
@@ -230,13 +230,14 @@ func (i *Input) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (i *Input) activeStyles() *FieldStyles {
-	if i.theme == nil {
-		return &ThemeCharm().Blurred
+	theme := i.theme
+	if theme == nil {
+		theme = ThemeCharm()
 	}
 	if i.focused {
-		return &i.theme.Focused
+		return &theme.Focused
 	}
-	return &i.theme.Blurred
+	return &theme.Blurred
 }
 
 // View renders the input field.

--- a/field_input.go
+++ b/field_input.go
@@ -47,7 +47,6 @@ func NewInput() *Input {
 		value:     new(string),
 		textinput: input,
 		validate:  func(string) error { return nil },
-		theme:     ThemeCharm(),
 	}
 
 	return i
@@ -230,12 +229,19 @@ func (i *Input) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return i, tea.Batch(cmds...)
 }
 
+func (i *Input) activeStyles() *FieldStyles {
+	if i.theme == nil {
+		return &ThemeCharm().Blurred
+	}
+	if i.focused {
+		return &i.theme.Focused
+	}
+	return &i.theme.Blurred
+}
+
 // View renders the input field.
 func (i *Input) View() string {
-	styles := i.theme.Blurred
-	if i.focused {
-		styles = i.theme.Focused
-	}
+	styles := i.activeStyles()
 
 	// NB: since the method is on a pointer receiver these are being mutated.
 	// Because this runs on every render this shouldn't matter in practice,
@@ -278,10 +284,11 @@ func (i *Input) run() error {
 
 // runAccessible runs the input field in accessible mode.
 func (i *Input) runAccessible() error {
-	fmt.Println(i.theme.Blurred.Base.Render(i.theme.Focused.Title.Render(i.title)))
+	styles := i.activeStyles()
+	fmt.Println(styles.Title.Render(i.title))
 	fmt.Println()
 	*i.value = accessibility.PromptString("Input: ", i.validate)
-	fmt.Println(i.theme.Focused.SelectedOption.Render("Input: " + *i.value + "\n"))
+	fmt.Println(styles.SelectedOption.Render("Input: " + *i.value + "\n"))
 	return nil
 }
 
@@ -300,17 +307,21 @@ func (i *Input) WithAccessible(accessible bool) Field {
 
 // WithTheme sets the theme of the input field.
 func (i *Input) WithTheme(theme *Theme) Field {
+	if i.theme != nil {
+		return i
+	}
 	i.theme = theme
 	return i
 }
 
 // WithWidth sets the width of the input field.
 func (i *Input) WithWidth(width int) Field {
+	styles := i.activeStyles()
 	i.width = width
-	frameSize := i.theme.Blurred.Base.GetHorizontalFrameSize()
+	frameSize := styles.Base.GetHorizontalFrameSize()
 	promptWidth := lipgloss.Width(i.textinput.PromptStyle.Render(i.textinput.Prompt))
-	titleWidth := lipgloss.Width(i.theme.Focused.Title.Render(i.title))
-	descriptionWidth := lipgloss.Width(i.theme.Focused.Description.Render(i.description))
+	titleWidth := lipgloss.Width(styles.Title.Render(i.title))
+	descriptionWidth := lipgloss.Width(styles.Description.Render(i.description))
 	i.textinput.Width = width - frameSize - promptWidth - 1
 	if i.inline {
 		i.textinput.Width -= titleWidth

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -55,7 +55,6 @@ func NewMultiSelect[T comparable]() *MultiSelect[T] {
 		validate:  func([]T) error { return nil },
 		filtering: false,
 		filter:    filter,
-		theme:     ThemeCharm(),
 	}
 }
 
@@ -338,6 +337,9 @@ func (m *MultiSelect[T]) finalize() {
 }
 
 func (m *MultiSelect[T]) activeStyles() *FieldStyles {
+	if m.theme == nil {
+		return &ThemeCharm().Blurred
+	}
 	if m.focused {
 		return &m.theme.Focused
 	}
@@ -419,21 +421,22 @@ func (m *MultiSelect[T]) View() string {
 }
 
 func (m *MultiSelect[T]) printOptions() {
+	styles := m.activeStyles()
 	var sb strings.Builder
 
-	sb.WriteString(m.theme.Focused.Title.Render(m.title))
+	sb.WriteString(styles.Title.Render(m.title))
 	sb.WriteString("\n")
 
 	for i, option := range m.options {
 		if option.selected {
-			sb.WriteString(m.theme.Focused.SelectedOption.Render(fmt.Sprintf("%d. %s %s", i+1, "✓", option.Key)))
+			sb.WriteString(styles.SelectedOption.Render(fmt.Sprintf("%d. %s %s", i+1, "✓", option.Key)))
 		} else {
 			sb.WriteString(fmt.Sprintf("%d. %s %s", i+1, " ", option.Key))
 		}
 		sb.WriteString("\n")
 	}
 
-	fmt.Println(m.theme.Blurred.Base.Render(sb.String()))
+	fmt.Println(sb.String())
 }
 
 // setFilter sets the filter of the select field.
@@ -464,6 +467,7 @@ func (m *MultiSelect[T]) Run() error {
 // runAccessible() runs the multi-select field in accessible mode.
 func (m *MultiSelect[T]) runAccessible() error {
 	m.printOptions()
+	styles := m.activeStyles()
 
 	var choice int
 	for {
@@ -503,12 +507,15 @@ func (m *MultiSelect[T]) runAccessible() error {
 		}
 	}
 
-	fmt.Println(m.theme.Focused.SelectedOption.Render("Selected:", strings.Join(values, ", ")+"\n"))
+	fmt.Println(styles.SelectedOption.Render("Selected:", strings.Join(values, ", ")+"\n"))
 	return nil
 }
 
 // WithTheme sets the theme of the multi-select field.
 func (m *MultiSelect[T]) WithTheme(theme *Theme) Field {
+	if m.theme != nil {
+		return m
+	}
 	m.theme = theme
 	m.filter.Cursor.Style = m.theme.Focused.TextInput.Cursor
 	m.filter.PromptStyle = m.theme.Focused.TextInput.Prompt

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -305,11 +305,6 @@ func (m *MultiSelect[T]) updateViewportHeight() {
 		return
 	}
 
-	// Wait until the theme has appied or things'll panic.
-	if m.theme == nil {
-		return
-	}
-
 	const minHeight = 1
 	m.viewport.Height = max(minHeight, m.height-
 		lipgloss.Height(m.titleView())-
@@ -337,13 +332,14 @@ func (m *MultiSelect[T]) finalize() {
 }
 
 func (m *MultiSelect[T]) activeStyles() *FieldStyles {
-	if m.theme == nil {
-		return &ThemeCharm().Blurred
+	theme := m.theme
+	if theme == nil {
+		theme = ThemeCharm()
 	}
 	if m.focused {
-		return &m.theme.Focused
+		return &theme.Focused
 	}
-	return &m.theme.Blurred
+	return &theme.Blurred
 }
 
 func (m *MultiSelect[T]) titleView() string {

--- a/field_note.go
+++ b/field_note.go
@@ -31,7 +31,6 @@ type Note struct {
 func NewNote() *Note {
 	return &Note{
 		showNextButton: false,
-		theme:          ThemeCharm(),
 		skip:           true,
 	}
 }
@@ -106,15 +105,21 @@ func (n *Note) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return n, nil
 }
 
+func (n *Note) activeStyles() *FieldStyles {
+	if n.theme == nil {
+		return &ThemeCharm().Blurred
+	}
+	if n.focused {
+		return &n.theme.Focused
+	}
+	return &n.theme.Focused
+}
+
 // View renders the note field.
 func (n *Note) View() string {
-	styles := n.theme.Blurred
-	if n.focused {
-		styles = n.theme.Focused
-	}
-
 	var (
-		sb strings.Builder
+		styles = n.activeStyles()
+		sb     strings.Builder
 	)
 
 	if n.title != "" {
@@ -148,13 +153,16 @@ func (n *Note) runAccessible() error {
 
 	body += n.description
 
-	fmt.Println(n.theme.Blurred.Base.Render(body))
+	fmt.Println(body)
 	fmt.Println()
 	return nil
 }
 
 // WithTheme sets the theme on a note field.
 func (n *Note) WithTheme(theme *Theme) Field {
+	if n.theme != nil {
+		return n
+	}
 	n.theme = theme
 	return n
 }

--- a/field_note.go
+++ b/field_note.go
@@ -106,13 +106,14 @@ func (n *Note) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (n *Note) activeStyles() *FieldStyles {
-	if n.theme == nil {
-		return &ThemeCharm().Blurred
+	theme := n.theme
+	if theme == nil {
+		theme = ThemeCharm()
 	}
 	if n.focused {
-		return &n.theme.Focused
+		return &theme.Focused
 	}
-	return &n.theme.Focused
+	return &theme.Focused
 }
 
 // View renders the note field.

--- a/field_select.go
+++ b/field_select.go
@@ -54,7 +54,6 @@ func NewSelect[T comparable]() *Select[T] {
 		validate:  func(T) error { return nil },
 		filtering: false,
 		filter:    filter,
-		theme:     ThemeCharm(),
 	}
 }
 
@@ -323,11 +322,6 @@ func (s *Select[T]) updateViewportHeight() {
 		return
 	}
 
-	// Wait until the theme has appied.
-	if s.theme == nil {
-		return
-	}
-
 	const minHeight = 1
 	s.viewport.Height = max(minHeight, s.height-
 		lipgloss.Height(s.titleView())-
@@ -336,7 +330,7 @@ func (s *Select[T]) updateViewportHeight() {
 
 func (s *Select[T]) activeStyles() *FieldStyles {
 	if s.theme == nil {
-		return nil
+		return &ThemeCharm().Blurred
 	}
 	if s.focused {
 		return &s.theme.Focused
@@ -462,15 +456,16 @@ func (s *Select[T]) Run() error {
 // runAccessible runs an accessible select field.
 func (s *Select[T]) runAccessible() error {
 	var sb strings.Builder
+	styles := s.activeStyles()
 
-	sb.WriteString(s.theme.Focused.Title.Render(s.title) + "\n")
+	sb.WriteString(styles.Title.Render(s.title) + "\n")
 
 	for i, option := range s.options {
 		sb.WriteString(fmt.Sprintf("%d. %s", i+1, option.Key))
 		sb.WriteString("\n")
 	}
 
-	fmt.Println(s.theme.Blurred.Base.Render(sb.String()))
+	fmt.Println(sb.String())
 
 	for {
 		choice := accessibility.PromptInt("Choose: ", 1, len(s.options))
@@ -479,7 +474,7 @@ func (s *Select[T]) runAccessible() error {
 			fmt.Println(err.Error())
 			continue
 		}
-		fmt.Println(s.theme.Focused.SelectedOption.Render("Chose: " + option.Key + "\n"))
+		fmt.Println(styles.SelectedOption.Render("Chose: " + option.Key + "\n"))
 		*s.value = option.Value
 		break
 	}
@@ -489,6 +484,9 @@ func (s *Select[T]) runAccessible() error {
 
 // WithTheme sets the theme of the select field.
 func (s *Select[T]) WithTheme(theme *Theme) Field {
+	if s.theme != nil {
+		return s
+	}
 	s.theme = theme
 	s.filter.Cursor.Style = s.theme.Focused.TextInput.Cursor
 	s.filter.PromptStyle = s.theme.Focused.TextInput.Prompt

--- a/field_select.go
+++ b/field_select.go
@@ -329,13 +329,14 @@ func (s *Select[T]) updateViewportHeight() {
 }
 
 func (s *Select[T]) activeStyles() *FieldStyles {
-	if s.theme == nil {
-		return &ThemeCharm().Blurred
+	theme := s.theme
+	if theme == nil {
+		theme = ThemeCharm()
 	}
 	if s.focused {
-		return &s.theme.Focused
+		return &theme.Focused
 	}
-	return &s.theme.Blurred
+	return &theme.Blurred
 }
 
 func (s *Select[T]) titleView() string {

--- a/field_text.go
+++ b/field_text.go
@@ -58,7 +58,6 @@ func NewText() *Text {
 		editorCmd:       editorCmd,
 		editorArgs:      editorArgs,
 		editorExtension: "md",
-		theme:           ThemeCharm(),
 	}
 
 	return t
@@ -243,19 +242,30 @@ func (t *Text) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return t, tea.Batch(cmds...)
 }
 
+func (t *Text) activeStyles() *FieldStyles {
+	if t.theme == nil {
+		return &ThemeCharm().Blurred
+	}
+	if t.focused {
+		return &t.theme.Focused
+	}
+	return &t.theme.Blurred
+}
+
+func (t *Text) activeTextAreaStyles() *textarea.Style {
+	if t.theme == nil {
+		return &t.textarea.BlurredStyle
+	}
+	if t.focused {
+		return &t.textarea.FocusedStyle
+	}
+	return &t.textarea.BlurredStyle
+}
+
 // View renders the text field.
 func (t *Text) View() string {
-	var (
-		styles         FieldStyles
-		textareaStyles *textarea.Style
-	)
-	if t.focused {
-		styles = t.theme.Focused
-		textareaStyles = &t.textarea.FocusedStyle
-	} else {
-		styles = t.theme.Blurred
-		textareaStyles = &t.textarea.BlurredStyle
-	}
+	var styles = t.activeStyles()
+	var textareaStyles = t.activeTextAreaStyles()
 
 	// NB: since the method is on a pointer receiver these are being mutated.
 	// Because this runs on every render this shouldn't matter in practice,
@@ -293,7 +303,8 @@ func (t *Text) Run() error {
 
 // runAccessible runs an accessible text field.
 func (t *Text) runAccessible() error {
-	fmt.Println(t.theme.Blurred.Base.Render(t.theme.Focused.Title.Render(t.title)))
+	styles := t.activeStyles()
+	fmt.Println(styles.Title.Render(t.title))
 	fmt.Println()
 	*t.value = accessibility.PromptString("Input: ", func(input string) error {
 		if err := t.validate(input); err != nil {
@@ -312,6 +323,9 @@ func (t *Text) runAccessible() error {
 
 // WithTheme sets the theme on a text field.
 func (t *Text) WithTheme(theme *Theme) Field {
+	if t.theme != nil {
+		return t
+	}
 	t.theme = theme
 	return t
 }
@@ -332,7 +346,7 @@ func (t *Text) WithAccessible(accessible bool) Field {
 // WithWidth sets the width of the text field.
 func (t *Text) WithWidth(width int) Field {
 	t.width = width
-	t.textarea.SetWidth(width - t.theme.Blurred.Base.GetHorizontalFrameSize())
+	t.textarea.SetWidth(width - t.activeStyles().Base.GetHorizontalFrameSize())
 	return t
 }
 
@@ -345,7 +359,7 @@ func (t *Text) WithHeight(height int) Field {
 	if t.description != "" {
 		adjust++
 	}
-	t.textarea.SetHeight(height - t.theme.Blurred.Base.GetVerticalFrameSize() - adjust)
+	t.textarea.SetHeight(height - t.activeStyles().Base.GetVerticalFrameSize() - adjust)
 	return t
 }
 

--- a/field_text.go
+++ b/field_text.go
@@ -243,13 +243,14 @@ func (t *Text) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (t *Text) activeStyles() *FieldStyles {
-	if t.theme == nil {
-		return &ThemeCharm().Blurred
+	theme := t.theme
+	if theme == nil {
+		theme = ThemeCharm()
 	}
 	if t.focused {
-		return &t.theme.Focused
+		return &theme.Focused
 	}
-	return &t.theme.Blurred
+	return &theme.Blurred
 }
 
 func (t *Text) activeTextAreaStyles() *textarea.Style {

--- a/form.go
+++ b/form.go
@@ -60,7 +60,6 @@ type Form struct {
 	// options
 	width      int
 	height     int
-	theme      *Theme
 	keymap     *KeyMap
 	teaOptions []tea.ProgramOption
 	output     io.Writer

--- a/form.go
+++ b/form.go
@@ -78,7 +78,6 @@ func NewForm(groups ...*Group) *Form {
 	f := &Form{
 		groups:    groups,
 		paginator: p,
-		theme:     ThemeCharm(),
 		keymap:    NewDefaultKeyMap(),
 		results:   make(map[string]any),
 		teaOptions: []tea.ProgramOption{
@@ -88,7 +87,6 @@ func NewForm(groups ...*Group) *Form {
 
 	// NB: If dynamic forms come into play this will need to be applied when
 	// groups and fields are added.
-	f.WithTheme(f.theme)
 	f.WithKeyMap(f.keymap)
 	f.WithWidth(f.width)
 	f.WithHeight(f.height)
@@ -238,7 +236,6 @@ func (f *Form) WithTheme(theme *Theme) *Form {
 	if theme == nil {
 		return f
 	}
-	f.theme = theme
 	for _, group := range f.groups {
 		group.WithTheme(theme)
 	}

--- a/group.go
+++ b/group.go
@@ -38,7 +38,6 @@ type Group struct {
 	// group options
 	width  int
 	height int
-	theme  *Theme
 	keymap *KeyMap
 	hide   func() bool
 }
@@ -91,7 +90,6 @@ func (g *Group) WithShowErrors(show bool) *Group {
 
 // WithTheme sets the theme on a group.
 func (g *Group) WithTheme(t *Theme) *Group {
-	g.theme = t
 	g.help.Styles = t.Help
 	for _, field := range g.fields {
 		field.WithTheme(t)
@@ -258,11 +256,7 @@ func (g *Group) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (g *Group) fullHeight() int {
 	var height int
 
-	if g.theme == nil {
-		return g.height // unknown
-	}
-
-	gap := g.theme.FieldSeparator.String()
+	gap := "\n\n"
 	if gap != "" {
 		height += len(g.fields)
 	}
@@ -276,10 +270,7 @@ func (g *Group) fullHeight() int {
 func (g *Group) buildView() {
 	var fields strings.Builder
 	offset := 0
-	gap := g.theme.FieldSeparator.String()
-	if gap == "" {
-		gap = "\n"
-	}
+	gap := "\n\n"
 
 	// if the focused field is requesting it be zoomed, only show that field.
 	if g.fields[g.paginator.Page].Zoom() {
@@ -312,7 +303,7 @@ func (g *Group) View() string {
 	}
 	if g.showErrors {
 		for _, err := range errors {
-			view.WriteString(g.theme.Focused.ErrorMessage.Render(err.Error()))
+			view.WriteString(ThemeCharm().Focused.ErrorMessage.Render(err.Error()))
 		}
 	}
 	return view.String()

--- a/group.go
+++ b/group.go
@@ -254,13 +254,7 @@ func (g *Group) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // height returns the full height of the group.
 func (g *Group) fullHeight() int {
-	var height int
-
-	gap := "\n\n"
-	if gap != "" {
-		height += len(g.fields)
-	}
-
+	height := len(g.fields)
 	for _, f := range g.fields {
 		height += lipgloss.Height(f.View())
 	}

--- a/huh_test.go
+++ b/huh_test.go
@@ -692,7 +692,6 @@ func TestPrevGroup(t *testing.T) {
 func TestNote(t *testing.T) {
 	field := NewNote().Title("Taco").Description("How may we take your order?").Next(true)
 	f := NewForm(NewGroup(field))
-	f.theme.Focused.Base.Border(lipgloss.HiddenBorder())
 	f.Update(f.Init())
 
 	view := ansi.Strip(f.View())


### PR DESCRIPTION
This PR allows overriding themes for fields and falls back to `ThemeCharm()` for
all inputs if no theme is specified.

---

Notes for future:

* Each field is responsible for its own style.
* Always use `activeStyles()` as theme can be `nil`.
* We may want to have some styles available for the group (`FieldSeparator` should be a field on the group, similar to `help` style), pulled when `WithTheme` is called.
