### PR TITLE
feat: optional setting of note next label

### DIFF
--- a/examples/burger/main.go
+++ b/examples/burger/main.go
@@ -59,7 +59,10 @@ func main() {
 	form := huh.NewForm(
 		huh.NewGroup(huh.NewNote().
 			Title("Charmburger").
-			Description("Welcome to _Charmburger™_.\n\nHow may we take your order?")),
+			Description("Welcome to _Charmburger™_.\n\nHow may we take your order?\n\n").
+			Next(true).
+			WithNextLabel("Let's go!"),
+		),
 
 		// Choose a burger.
 		// We'll need to know what topping to add too.

--- a/examples/burger/main.go
+++ b/examples/burger/main.go
@@ -61,7 +61,7 @@ func main() {
 			Title("Charmburger").
 			Description("Welcome to _Charmburger™_.\n\nHow may we take your order?\n\n").
 			Next(true).
-			WithNextLabel("Let's go!"),
+			NextLabel("Let's go!"),
 		),
 
 		// Choose a burger.

--- a/field_note.go
+++ b/field_note.go
@@ -55,6 +55,12 @@ func (n *Note) Next(show bool) *Note {
 	return n
 }
 
+// NextLabel sets the next button label.
+func (n *Note) NextLabel(label string) *Note {
+	n.nextLabel = label
+	return n
+}
+
 // Focus focuses the note field.
 func (n *Note) Focus() tea.Cmd {
 	n.focused = true
@@ -204,12 +210,6 @@ func (n *Note) WithPosition(p FieldPosition) Field {
 	n.keymap.Prev.SetEnabled(!p.IsFirst())
 	n.keymap.Next.SetEnabled(!p.IsLast())
 	n.keymap.Submit.SetEnabled(p.IsLast())
-	return n
-}
-
-// WithNextLabel sets the next button label.
-func (n *Note) WithNextLabel(label string) Field {
-	n.nextLabel = label
 	return n
 }
 

--- a/field_note.go
+++ b/field_note.go
@@ -13,6 +13,7 @@ type Note struct {
 	// customization
 	title       string
 	description string
+	nextLabel   string
 
 	// state
 	showNextButton bool
@@ -25,7 +26,6 @@ type Note struct {
 	accessible bool
 	theme      *Theme
 	keymap     NoteKeyMap
-	nextLabel  string
 }
 
 // NewNote creates a new note field.

--- a/field_note.go
+++ b/field_note.go
@@ -25,6 +25,7 @@ type Note struct {
 	accessible bool
 	theme      *Theme
 	keymap     NoteKeyMap
+	nextLabel  string
 }
 
 // NewNote creates a new note field.
@@ -32,6 +33,7 @@ func NewNote() *Note {
 	return &Note{
 		showNextButton: false,
 		skip:           true,
+		nextLabel:      "Next",
 	}
 }
 
@@ -131,7 +133,7 @@ func (n *Note) View() string {
 		sb.WriteString(render(n.description))
 	}
 	if n.showNextButton {
-		sb.WriteString(styles.Next.Render("Next"))
+		sb.WriteString(styles.Next.Render(n.nextLabel))
 	}
 	return styles.Card.Render(sb.String())
 }
@@ -202,6 +204,12 @@ func (n *Note) WithPosition(p FieldPosition) Field {
 	n.keymap.Prev.SetEnabled(!p.IsFirst())
 	n.keymap.Next.SetEnabled(!p.IsLast())
 	n.keymap.Submit.SetEnabled(p.IsLast())
+	return n
+}
+
+// WithNextLabel sets the next button label.
+func (n *Note) WithNextLabel(label string) Field {
+	n.nextLabel = label
 	return n
 }
 


### PR DESCRIPTION
I'd like to be able to set the label on the note next button. This change allows this through a `WithNextLabel` func. If this isn't used, then will default to 'Next'.