### PR TITLE
feat: expose results by shallow copy

### DIFF
--- a/form.go
+++ b/form.go
@@ -586,3 +586,14 @@ func (f *Form) runAccessible() error {
 
 	return nil
 }
+
+// Results returns a shallow copy of the results map.
+func (f *Form) Results() map[string]any {
+	cp := make(map[string]any, len(f.results))
+
+	for k, v := range f.results {
+		cp[k] = v
+	}
+
+	return cp
+}


### PR DESCRIPTION
I am migrating my scaffolding tool to use `huh` and am running into a few limitations. One of which is that, that I don't know what my form will look likes keys or values at build time, only at runtime do I know. The Fields are generated dynamically by a user configuration file. 

As such, I need some way to get that data out of the form to continue onto the template engine. 

This PR exposes the underlying map inside of the `Form` type by shallow copy. I think in most cases, this should be fine?

--

I can work around this limitation by saving a copy of the keys and getting them out of the `Form` using the existing `GetValue` method, but this saves me a few steps. If you want to keep this internal only let me know! 

Love the project!