### PR TITLE
fix(multiselect): check if is filterable before enable filtering

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -522,6 +522,7 @@ func (m *MultiSelect[T]) WithTheme(theme *Theme) Field {
 // WithKeyMap sets the keymap of the multi-select field.
 func (m *MultiSelect[T]) WithKeyMap(k *KeyMap) Field {
 	m.keymap = k.MultiSelect
+	m.keymap.Filter.SetEnabled(m.filterable)
 	return m
 }
 

--- a/huh_test.go
+++ b/huh_test.go
@@ -478,7 +478,20 @@ func TestMultiSelect(t *testing.T) {
 		t.Error("Expected cursor to be on Bar.")
 	}
 
+	field.Filterable(true)
+	f = NewForm(NewGroup(field))
+	f.Update(f.Init())
+	view = ansi.Strip(m.View())
 	if !strings.Contains(view, "x toggle • ↑ up • ↓ down • / filter • enter submit") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected field to contain help.")
+	}
+
+	field.Filterable(false)
+	f = NewForm(NewGroup(field))
+	f.Update(f.Init())
+	view = ansi.Strip(m.View())
+	if !strings.Contains(view, "x toggle • ↑ up • ↓ down • enter submit") {
 		t.Log(pretty.Render(view))
 		t.Error("Expected field to contain help.")
 	}


### PR DESCRIPTION
Fixes #251 

### Changes: 
 - Check if the multi select is filterable before changing the state to filtering.
 - Update the test accordingly to the change