### PR TITLE
feat: add a key getter func to options

### DIFF
--- a/option.go
+++ b/option.go
@@ -21,6 +21,18 @@ func NewOptions[T comparable](values ...T) []Option[T] {
 	return options
 }
 
+// ToOptions returns new options from a list of values and a key getter. 
+func ToOptions[T comparable](getKey func(T) string, values ...T) []Option[T] {
+	options := make([]Option[T], len(values))
+	for i, o := range values {
+		options[i] = Option[T]{
+			Key:   getKey(o),
+			Value: o,
+		}
+	}
+	return options
+}
+
 // NewOption returns a new select option.
 func NewOption[T comparable](key string, value T) Option[T] {
 	return Option[T]{Key: key, Value: value}


### PR DESCRIPTION
Add a method to get the key from the value to generate the options.
```go
type People struct {
    Name string
    Age  int
}
NewSelect[People]().Options(ToOptions(func(p People) string { return p.Name }, 
    People{Name: "Foo", Age: 20}, 
    People{Name: "Bar", Age: 25}, 
    People{Name: "Baz", Age: 23},
)...)
```