### PR TITLE
feat: adjust input width to char limit

### DIFF
--- a/field_input.go
+++ b/field_input.go
@@ -252,6 +252,11 @@ func (i *Input) View() string {
 	i.textinput.Cursor.Style = styles.TextInput.Cursor
 	i.textinput.TextStyle = styles.TextInput.Text
 
+	// Adjust text input size to its char limit if it fit in its width
+	if i.textinput.CharLimit > 0 {
+		i.textinput.Width = min(i.textinput.CharLimit, i.textinput.Width)
+	}
+
 	var sb strings.Builder
 	if i.title != "" {
 		sb.WriteString(styles.Title.Render(i.title))


### PR DESCRIPTION
When using non transparent background for char limited input text, the field weirdly fill all the layout view, resulting in a poor user interface experience.

In this example, `CharLimit` is set to `12`:
<img width="1303" alt="Capture d’écran 2024-05-29 à 14 57 29" src="https://github.com/charmbracelet/huh/assets/95935/d3c1321f-4a9f-4eac-bb22-3fdacddf5e15">

This pr adjusts its final width during the view time, letting the `WithWidth` method doing the hard job

And voila:
<img width="453" alt="Capture d’écran 2024-05-29 à 15 07 35" src="https://github.com/charmbracelet/huh/assets/95935/0b091e06-1a24-4de5-849e-811aa54f2540">

And before you asks, yes it supports inline mode:
<img width="316" alt="Capture d’écran 2024-05-29 à 15 22 37" src="https://github.com/charmbracelet/huh/assets/95935/629dbe2b-3567-480a-bd5a-6f62883611ef">
