### PR TITLE
feat: introduce accessor

### DIFF
--- a/accessor.go
+++ b/accessor.go
@@ -1,0 +1,44 @@
+package huh
+
+// Accessor give read/write access to field values.
+type Accessor[T any] interface {
+	Get() T
+	Set(value T)
+}
+
+// EmbeddedAccessor is a basic accessor, acting as the default one for fields.
+type EmbeddedAccessor[T any] struct {
+	value T
+}
+
+// Get gets the value.
+func (a *EmbeddedAccessor[T]) Get() T {
+	return a.value
+}
+
+// Set sets the value.
+func (a *EmbeddedAccessor[T]) Set(value T) {
+	a.value = value
+}
+
+// PointerAccessor allows field value to be exposed as a pointed variable.
+type PointerAccessor[T any] struct {
+	value *T
+}
+
+// NewPointerAccessor returns a new pointer accessor.
+func NewPointerAccessor[T any](value *T) *PointerAccessor[T] {
+	return &PointerAccessor[T]{
+		value: value,
+	}
+}
+
+// Get gets the value.
+func (a *PointerAccessor[T]) Get() T {
+	return *a.value
+}
+
+// Set sets the value.
+func (a *PointerAccessor[T]) Set(value T) {
+	*a.value = value
+}

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -14,8 +14,8 @@ import (
 
 // MultiSelect is a form multi-select field.
 type MultiSelect[T comparable] struct {
-	value *[]T
-	key   string
+	accessor Accessor[[]T]
+	key      string
 
 	// customization
 	title           string
@@ -51,7 +51,7 @@ func NewMultiSelect[T comparable]() *MultiSelect[T] {
 
 	return &MultiSelect[T]{
 		options:   []Option[T]{},
-		value:     new([]T),
+		accessor:  &EmbeddedAccessor[[]T]{},
 		validate:  func([]T) error { return nil },
 		filtering: false,
 		filter:    filter,
@@ -60,9 +60,14 @@ func NewMultiSelect[T comparable]() *MultiSelect[T] {
 
 // Value sets the value of the multi-select field.
 func (m *MultiSelect[T]) Value(value *[]T) *MultiSelect[T] {
-	m.value = value
+	return m.Accessor(NewPointerAccessor(value))
+}
+
+// Accessor sets the accessor of the input field.
+func (m *MultiSelect[T]) Accessor(accessor Accessor[[]T]) *MultiSelect[T] {
+	m.accessor = accessor
 	for i, o := range m.options {
-		for _, v := range *value {
+		for _, v := range m.accessor.Get() {
 			if o.Value == v {
 				m.options[i].selected = true
 				break
@@ -98,7 +103,7 @@ func (m *MultiSelect[T]) Options(options ...Option[T]) *MultiSelect[T] {
 	}
 
 	for i, o := range options {
-		for _, v := range *m.value {
+		for _, v := range m.accessor.Get() {
 			if o.Value == v {
 				options[i].selected = true
 				break
@@ -322,13 +327,14 @@ func (m *MultiSelect[T]) numSelected() int {
 }
 
 func (m *MultiSelect[T]) finalize() {
-	*m.value = make([]T, 0)
+	value := make([]T, 0)
 	for _, option := range m.options {
 		if option.selected {
-			*m.value = append(*m.value, option.Value)
+			value = append(value, option.Value)
 		}
 	}
-	m.err = m.validate(*m.value)
+	m.accessor.Set(value)
+	m.err = m.validate(m.accessor.Get())
 }
 
 func (m *MultiSelect[T]) activeStyles() *FieldStyles {
@@ -472,7 +478,7 @@ func (m *MultiSelect[T]) runAccessible() error {
 		choice = accessibility.PromptInt("Select: ", 0, len(m.options))
 		if choice == 0 {
 			m.finalize()
-			err := m.validate(*m.value)
+			err := m.validate(m.accessor.Get())
 			if err != nil {
 				fmt.Println(err)
 				continue
@@ -496,12 +502,14 @@ func (m *MultiSelect[T]) runAccessible() error {
 
 	var values []string
 
+	value := m.accessor.Get()
 	for _, option := range m.options {
 		if option.selected {
-			*m.value = append(*m.value, option.Value)
+			value = append(value, option.Value)
 			values = append(values, option.Key)
 		}
 	}
+	m.accessor.Set(value)
 
 	fmt.Println(styles.SelectedOption.Render("Selected:", strings.Join(values, ", ")+"\n"))
 	return nil
@@ -562,5 +570,5 @@ func (m *MultiSelect[T]) GetKey() string {
 
 // GetValue returns the multi-select's value.
 func (m *MultiSelect[T]) GetValue() any {
-	return *m.value
+	return m.accessor.Get()
 }

--- a/field_select.go
+++ b/field_select.go
@@ -14,7 +14,7 @@ import (
 
 // Select is a form select field.
 type Select[T comparable] struct {
-	value    *T
+	accessor Accessor[T]
 	key      string
 	viewport viewport.Model
 
@@ -50,7 +50,7 @@ func NewSelect[T comparable]() *Select[T] {
 
 	return &Select[T]{
 		options:   []Option[T]{},
-		value:     new(T),
+		accessor:  &EmbeddedAccessor[T]{},
 		validate:  func(T) error { return nil },
 		filtering: false,
 		filter:    filter,
@@ -59,8 +59,13 @@ func NewSelect[T comparable]() *Select[T] {
 
 // Value sets the value of the select field.
 func (s *Select[T]) Value(value *T) *Select[T] {
-	s.value = value
-	s.selectValue(*value)
+	return s.Accessor(NewPointerAccessor(value))
+}
+
+// Accessor sets the accessor of the select field.
+func (s *Select[T]) Accessor(accessor Accessor[T]) *Select[T] {
+	s.accessor = accessor
+	s.selectValue(s.accessor.Get())
 	return s
 }
 
@@ -102,7 +107,7 @@ func (s *Select[T]) Options(options ...Option[T]) *Select[T] {
 
 	// Set the cursor to the existing value or the last selected option.
 	for i, option := range options {
-		if option.Value == *s.value {
+		if option.Value == s.accessor.Get() {
 			s.selected = i
 			break
 		} else if option.selected {
@@ -165,7 +170,7 @@ func (s *Select[T]) Focus() tea.Cmd {
 
 // Blur blurs the select field.
 func (s *Select[T]) Blur() tea.Cmd {
-	value := *s.value
+	value := s.accessor.Get()
 	if s.inline {
 		s.clearFilter()
 		s.selectValue(value)
@@ -277,7 +282,7 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if s.err != nil {
 				return s, nil
 			}
-			*s.value = value
+			s.accessor.Set(value)
 			return s, PrevField
 		case key.Matches(msg, s.keymap.Next, s.keymap.Submit):
 			if s.selected >= len(s.filteredOptions) {
@@ -289,7 +294,7 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if s.err != nil {
 				return s, nil
 			}
-			*s.value = value
+			s.accessor.Set(value)
 			return s, NextField
 		}
 
@@ -476,7 +481,7 @@ func (s *Select[T]) runAccessible() error {
 			continue
 		}
 		fmt.Println(styles.SelectedOption.Render("Chose: " + option.Key + "\n"))
-		*s.value = option.Value
+		s.accessor.Set(option.Value)
 		break
 	}
 
@@ -541,5 +546,5 @@ func (s *Select[T]) GetKey() string {
 
 // GetValue returns the value of the field.
 func (s *Select[T]) GetValue() any {
-	return *s.value
+	return s.accessor.Get()
 }

--- a/huh_test.go
+++ b/huh_test.go
@@ -297,6 +297,10 @@ func TestInput(t *testing.T) {
 		t.Log(pretty.Render(view))
 		t.Error("Expected field to contain help.")
 	}
+
+	if field.GetValue() != "Huh" {
+		t.Error("Expected field value to be Huh")
+	}
 }
 
 func TestInlineInput(t *testing.T) {
@@ -335,6 +339,10 @@ func TestInlineInput(t *testing.T) {
 		t.Log(pretty.Render(view))
 		t.Error("Expected field to contain help.")
 	}
+
+	if field.GetValue() != "Huh" {
+		t.Error("Expected field value to be Huh")
+	}
 }
 
 func TestText(t *testing.T) {
@@ -355,6 +363,10 @@ func TestText(t *testing.T) {
 	if !strings.Contains(view, "alt+enter / ctrl+j new line • ctrl+e open editor • enter submit") {
 		t.Log(pretty.Render(view))
 		t.Error("Expected field to contain help.")
+	}
+
+	if field.GetValue() != "Huh" {
+		t.Error("Expected field value to be Huh")
 	}
 }
 
@@ -387,6 +399,24 @@ func TestConfirm(t *testing.T) {
 		t.Log(pretty.Render(view))
 		t.Error("Expected field to contain help.")
 	}
+
+	if field.GetValue() != false {
+		t.Error("Expected field value to be false")
+	}
+
+	// Toggle left
+	m, _ = f.Update(tea.KeyMsg{Type: tea.KeyLeft})
+
+	if field.GetValue() != true {
+		t.Error("Expected field value to be true")
+	}
+
+	// Toggle right
+	m, _ = f.Update(tea.KeyMsg{Type: tea.KeyRight})
+
+	if field.GetValue() != false {
+		t.Error("Expected field value to be false")
+	}
 }
 
 func TestSelect(t *testing.T) {
@@ -406,13 +436,13 @@ func TestSelect(t *testing.T) {
 		t.Error("Expected field to contain Which one?.")
 	}
 
-	// Move selection cursor down
 	if !strings.Contains(view, "> Foo") {
 		t.Log(pretty.Render(view))
 		t.Error("Expected cursor to be on Foo.")
 	}
 
-	m, _ := f.Update(keys('j'))
+	// Move selection cursor down
+	m, _ := f.Update(tea.KeyMsg{Type: tea.KeyDown})
 	f = m.(*Form)
 
 	view = ansi.Strip(f.View())
@@ -430,6 +460,14 @@ func TestSelect(t *testing.T) {
 	if !strings.Contains(view, "↑ up • ↓ down • / filter • enter submit") {
 		t.Log(pretty.Render(view))
 		t.Error("Expected field to contain help.")
+	}
+
+	// Submit
+	m, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	f = m.(*Form)
+
+	if field.GetValue() != "Bar" {
+		t.Error("Expected field value to be Bar")
 	}
 }
 
@@ -481,6 +519,23 @@ func TestMultiSelect(t *testing.T) {
 	if !strings.Contains(view, "x toggle • ↑ up • ↓ down • / filter • enter submit") {
 		t.Log(pretty.Render(view))
 		t.Error("Expected field to contain help.")
+	}
+
+	// Submit
+	m, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	f = m.(*Form)
+
+	value := field.GetValue()
+	if value, ok := value.([]string); !ok {
+		t.Error("Expected field value to a slice of string")
+	} else {
+		if len(value) != 1 {
+			t.Error("Expected field value length to be 1")
+		} else {
+			if value[0] != "Bar" {
+				t.Error("Expected first field value length to be Bar")
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This pr introduce a new (and simple) `Accessor` interface to enhance the form field values handling in a fully backward compatible way.

This interface is generic and contains only two method `Set` (for - guess what - setting value) an `Get` (you got it, for getting value).

The `Value` method of fields is very limited, and give only one way to expose fields values - via a variable pointer - with no other possibilities.
~~I propose to deprecate it in favor of an `Accessor` to define well... the field accessor :)~~
I propose a new `Accessor` method to define well... the field accessor :) Under the hood, `Value` method still exists but makes usage of an accessor.

Two generics accessors are already available:
- `EmbeddedAccessor` which replace the current behavior of fields when no variable pointer has been defined via `Value` method.
- `PointerAccessor` wich replace the current behavior of fields when a variable pointer is defined via `Value` method.

```golang
// Good ol' fashion
.Value(&foo)
// New shiny one
.Accessor(NewPointerAccessor(&foo))
```

Custom accessors can now be defined by end users :)