### PR TITLE
feature suggestion: make callbacks configurable

### DIFF
--- a/form.go
+++ b/form.go
@@ -589,20 +589,10 @@ type CallbackOptions struct {
 	CancelCmd tea.Cmd
 }
 
-func (f *Form) RunWithCallbacks(options CallbackOptions) error {
-	f.SubmitCmd = options.SubmitCmd
-	f.CancelCmd = options.CancelCmd
-	return f.Run()
-}
-
 // Run runs the form.
 func (f *Form) Run() error {
-	if f.SubmitCmd == nil {
-		f.SubmitCmd = tea.Quit
-	}
-	if f.CancelCmd == nil {
-		f.CancelCmd = tea.Quit
-	}
+	f.SubmitCmd = tea.Quit
+	f.CancelCmd = tea.Quit
 
 	if len(f.groups) == 0 {
 		return nil

--- a/form.go
+++ b/form.go
@@ -49,8 +49,8 @@ type Form struct {
 	paginator paginator.Model
 
 	// callbacks
-	submitCmd tea.Cmd
-	cancelCmd tea.Cmd
+	SubmitCmd tea.Cmd
+	CancelCmd tea.Cmd
 
 	State FormState
 
@@ -501,7 +501,7 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			f.aborted = true
 			f.quitting = true
 			f.State = StateAborted
-			return f, f.cancelCmd
+			return f, f.CancelCmd
 		}
 
 	case nextFieldMsg:
@@ -517,7 +517,7 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		submit := func() (tea.Model, tea.Cmd) {
 			f.quitting = true
 			f.State = StateCompleted
-			return f, f.submitCmd
+			return f, f.SubmitCmd
 		}
 
 		if f.paginator.OnLastPage() {
@@ -584,10 +584,25 @@ func (f *Form) View() string {
 	return f.layout.View(f)
 }
 
+type CallbackOptions struct {
+	SubmitCmd tea.Cmd
+	CancelCmd tea.Cmd
+}
+
+func (f *Form) RunWithCallbacks(options CallbackOptions) error {
+	f.SubmitCmd = options.SubmitCmd
+	f.CancelCmd = options.CancelCmd
+	return f.Run()
+}
+
 // Run runs the form.
 func (f *Form) Run() error {
-	f.submitCmd = tea.Quit
-	f.cancelCmd = tea.Quit
+	if f.SubmitCmd == nil {
+		f.SubmitCmd = tea.Quit
+	}
+	if f.CancelCmd == nil {
+		f.CancelCmd = tea.Quit
+	}
 
 	if len(f.groups) == 0 {
 		return nil

--- a/form.go
+++ b/form.go
@@ -584,11 +584,6 @@ func (f *Form) View() string {
 	return f.layout.View(f)
 }
 
-type CallbackOptions struct {
-	SubmitCmd tea.Cmd
-	CancelCmd tea.Cmd
-}
-
 // Run runs the form.
 func (f *Form) Run() error {
 	f.SubmitCmd = tea.Quit


### PR DESCRIPTION
I'm using `huh` to make some internal tooling with neat little TUI's. 

In this case, we have suite of tools that are their own individual `huh` forms. These can be used as top level forms, but I've also set things up in a way where forms can compose other forms that are otherwise top level. This uses a pattern commonly referred to as [Nested Tea](https://sporto.github.io/elm-patterns/architecture/nested-tea.html). Some of our tools are sometimes the top level form, other times they're forms within a form and this pattern makes them super composable.

It's a bit tricky, to compose them in this way, however. It often involves a line that looks sort of like this:
```go
	if m.subFormFoo != nil && m.subFormFoo.State == huh.StateCompleted {
		cmd = tea.Batch(cmd, getData(m))
		m.subFormFoo = nil
	}
       
	switch curmsg := msg.(type) {
	case getDataSuccess:
		m.subFormBar = NewFormBar()
                cmd = tea.Batch(cmd, subFormBar.Init())
```

The tricky part is `if-statements` in the control flow of update. Missing simple statements like `m.subFormFoo = nil` can cause a bad loop. When callbacks are configurable things become much easier and everything can stay in the msg/update pattern:
```go
	switch curmsg := msg.(type) {
        case subFormFooCompeted:
                cmd = tea.Batch(cmd, getData(m))
	case getDataSuccess:
		m.subFormBar = NewFormBar()
                cmd = tea.Batch(cmd, subFormBar.Init())
        case subFormBarCompleted:
               // more control flow etc,
```

Initializing a new form in this way is pretty straight forward

```go
func NewFormBar(m Model) *huh.Form {
	var form *huh.Form
	form = huh.NewForm(
		// cool huh stuff here
	)
	form.CancelCmd = func() tea.Msg {
		return subFormBarCancelled{}
	}
	form.SubmitCmd = func() tea.Msg {
		return subFormBarCompleted{}
	}
	return form
}
```

Notice that in these cases we aren't using `form.Run()` to run a form because it's undesirable to have it call `tea.Quit` when that form is submitted.

For this reason it isn't necessary to use the `RunWithCallbacks` function I added here. That would be used for top level forms where we want to stay in the "TEA mode" when the form is exited.


