### PR TITLE
fix: Fix invalid order of event handling in input/text fields

### DIFF
--- a/field_input.go
+++ b/field_input.go
@@ -205,10 +205,6 @@ func (i *Input) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	var cmd tea.Cmd
 
-	i.textinput, cmd = i.textinput.Update(msg)
-	cmds = append(cmds, cmd)
-	i.accessor.Set(i.textinput.Value())
-
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		i.err = nil
@@ -230,6 +226,10 @@ func (i *Input) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, NextField)
 		}
 	}
+
+	i.textinput, cmd = i.textinput.Update(msg)
+	cmds = append(cmds, cmd)
+	i.accessor.Set(i.textinput.Value())
 
 	return i, tea.Batch(cmds...)
 }

--- a/field_text.go
+++ b/field_text.go
@@ -202,10 +202,6 @@ func (t *Text) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	var cmd tea.Cmd
 
-	t.textarea, cmd = t.textarea.Update(msg)
-	cmds = append(cmds, cmd)
-	t.accessor.Set(t.textarea.Value())
-
 	switch msg := msg.(type) {
 	case updateValueMsg:
 		t.textarea.SetValue(string(msg))
@@ -243,6 +239,10 @@ func (t *Text) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, PrevField)
 		}
 	}
+
+	t.textarea, cmd = t.textarea.Update(msg)
+	cmds = append(cmds, cmd)
+	t.accessor.Set(t.textarea.Value())
 
 	return t, tea.Batch(cmds...)
 }


### PR DESCRIPTION
> **Follow up of** charmbracelet/bubbletea#1041, although they do not directly require each other.

Key binds should be checked before the key event is accepted as user input. Otherwise, control sequences or other keys might be printed instead of being interpreted as a key bind. See the above-mentioned PR for more information.