### PR TITLE
refactor(input): Skip validation when going to previous field

### DIFF
--- a/field_input.go
+++ b/field_input.go
@@ -215,11 +215,6 @@ func (i *Input) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch {
 		case key.Matches(msg, i.keymap.Prev):
-			value := i.textinput.Value()
-			i.err = i.validate(value)
-			if i.err != nil {
-				return i, nil
-			}
 			cmds = append(cmds, PrevField)
 		case key.Matches(msg, i.keymap.Next, i.keymap.Submit):
 			value := i.textinput.Value()


### PR DESCRIPTION
In my opinion, this would make user experience better. Say you made a typo in the previous field but you already went to the next one, now you *need* to fill the current field correctly before you can fix the previous field.

This also keeps validation intact, because the field still needs to be valid to progress to the next field.