### PR TITLE
Refactored option rendering in field_select.go to improve distinction

### DIFF
--- a/field_select.go
+++ b/field_select.go
@@ -564,7 +564,7 @@ func (s *Select[T]) optionsView() string {
 		if s.selected == i {
 			sb.WriteString(c + styles.SelectedOption.Render(option.Key))
 		} else {
-			sb.WriteString(strings.Repeat(" ", lipgloss.Width(c)) + styles.Option.Render(option.Key))
+			sb.WriteString(strings.Repeat(" ", lipgloss.Width(c)) + styles.UnselectedOption.Render(option.Key))
 		}
 		if i < len(s.options.val)-1 {
 			sb.WriteString("\n")


### PR DESCRIPTION
Fixed rendering of unselected options in the select field. Previously, all options were displayed with the same style regardless of their selection state. Now, unselected options will be appropriately rendered with an 'UnselectedOption' style. 

ref: https://github.com/charmbracelet/gum/issues/614