### PR TITLE
Added Accept and Reject key bindings to Confirm field in Keymap.

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -268,19 +268,19 @@ func (c *Confirm) View() string {
 
 	c.keymap.Accept.SetHelp("y", c.affirmative)
 
-	buttons := lipgloss.JoinHorizontal(lipgloss.Center, affirmative, negative)
+	buttonsRow := lipgloss.JoinHorizontal(lipgloss.Center, affirmative, negative)
 
-	prompt_width := lipgloss.Width(sb.String())
-	buttons_width := lipgloss.Width(buttons)
+	promptWidth := lipgloss.Width(sb.String())
+	buttonsWidth := lipgloss.Width(buttonsRow)
 
-	render_width := prompt_width
-	if buttons_width > render_width {
-		render_width = buttons_width
+	renderWidth := promptWidth
+	if buttonsWidth > renderWidth {
+		renderWidth = buttonsWidth
 	}
 
-	style := lipgloss.NewStyle().Width(render_width).Align(lipgloss.Center)
+	style := lipgloss.NewStyle().Width(renderWidth).Align(lipgloss.Center)
 
-	sb.WriteString(style.Render(buttons))
+	sb.WriteString(style.Render(buttonsRow))
 	return styles.Base.Render(sb.String())
 }
 

--- a/field_confirm.go
+++ b/field_confirm.go
@@ -150,7 +150,7 @@ func (c *Confirm) Blur() tea.Cmd {
 
 // KeyBinds returns the help message for the confirm field.
 func (c *Confirm) KeyBinds() []key.Binding {
-	return []key.Binding{c.keymap.Toggle, c.keymap.Prev, c.keymap.Submit, c.keymap.Next}
+	return []key.Binding{c.keymap.Toggle, c.keymap.Prev, c.keymap.Submit, c.keymap.Next, c.keymap.Accept, c.keymap.Reject}
 }
 
 // Init initializes the confirm field.
@@ -204,6 +204,12 @@ func (c *Confirm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, c.keymap.Prev):
 			cmds = append(cmds, PrevField)
 		case key.Matches(msg, c.keymap.Next, c.keymap.Submit):
+			cmds = append(cmds, NextField)
+		case key.Matches(msg, c.keymap.Accept):
+			c.accessor.Set(true)
+			cmds = append(cmds, NextField)
+		case key.Matches(msg, c.keymap.Reject):
+			c.accessor.Set(false)
 			cmds = append(cmds, NextField)
 		}
 	}

--- a/field_confirm.go
+++ b/field_confirm.go
@@ -268,7 +268,19 @@ func (c *Confirm) View() string {
 
 	c.keymap.Accept.SetHelp("y", c.affirmative)
 
-	sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Center, affirmative, negative))
+	buttons := lipgloss.JoinHorizontal(lipgloss.Center, affirmative, negative)
+
+	prompt_width := lipgloss.Width(sb.String())
+	buttons_width := lipgloss.Width(buttons)
+
+	render_width := prompt_width
+	if buttons_width > render_width {
+		render_width = buttons_width
+	}
+
+	style := lipgloss.NewStyle().Width(render_width).Align(lipgloss.Center)
+
+	sb.WriteString(style.Render(buttons))
 	return styles.Base.Render(sb.String())
 }
 

--- a/field_confirm.go
+++ b/field_confirm.go
@@ -260,9 +260,13 @@ func (c *Confirm) View() string {
 			affirmative = styles.BlurredButton.Render(c.affirmative)
 			negative = styles.FocusedButton.Render(c.negative)
 		}
+		c.keymap.Reject.SetHelp("n", c.negative)
 	} else {
 		affirmative = styles.FocusedButton.Render(c.affirmative)
+		c.keymap.Reject.SetEnabled(false)
 	}
+
+	c.keymap.Accept.SetHelp("y", c.affirmative)
 
 	sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Center, affirmative, negative))
 	return styles.Base.Render(sb.String())

--- a/keymap.go
+++ b/keymap.go
@@ -174,7 +174,7 @@ func NewDefaultKeyMap() *KeyMap {
 			Prev:   key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "back")),
 			Next:   key.NewBinding(key.WithKeys("enter", "tab"), key.WithHelp("enter", "next")),
 			Submit: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "submit")),
-			Toggle: key.NewBinding(key.WithKeys("h", "l", "right", "left"), key.WithHelp("←/→", "toggle")),
+			Toggle: key.NewBinding(key.WithKeys("h", "l", "right", "left", "tab", "shift+tab"), key.WithHelp("←/→", "toggle")),
 			Accept: key.NewBinding(key.WithKeys("y", "Y"), key.WithHelp("y", "Yes")),
 			Reject: key.NewBinding(key.WithKeys("n", "N"), key.WithHelp("n", "No")),
 		},

--- a/keymap.go
+++ b/keymap.go
@@ -175,8 +175,8 @@ func NewDefaultKeyMap() *KeyMap {
 			Next:   key.NewBinding(key.WithKeys("enter", "tab"), key.WithHelp("enter", "next")),
 			Submit: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "submit")),
 			Toggle: key.NewBinding(key.WithKeys("h", "l", "right", "left"), key.WithHelp("←/→", "toggle")),
-			Accept: key.NewBinding(key.WithKeys("y", "Y"), key.WithHelp("y/Y", "accept")),
-			Reject: key.NewBinding(key.WithKeys("n", "N"), key.WithHelp("n/N", "reject")),
+			Accept: key.NewBinding(key.WithKeys("y", "Y"), key.WithHelp("y", "Yes")),
+			Reject: key.NewBinding(key.WithKeys("n", "N"), key.WithHelp("n", "No")),
 		},
 	}
 }

--- a/keymap.go
+++ b/keymap.go
@@ -97,6 +97,8 @@ type ConfirmKeyMap struct {
 	Prev   key.Binding
 	Toggle key.Binding
 	Submit key.Binding
+	Accept key.Binding
+	Reject key.Binding
 }
 
 // NewDefaultKeyMap returns a new default keymap.
@@ -173,6 +175,8 @@ func NewDefaultKeyMap() *KeyMap {
 			Next:   key.NewBinding(key.WithKeys("enter", "tab"), key.WithHelp("enter", "next")),
 			Submit: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "submit")),
 			Toggle: key.NewBinding(key.WithKeys("h", "l", "right", "left"), key.WithHelp("←/→", "toggle")),
+			Accept: key.NewBinding(key.WithKeys("y", "Y"), key.WithHelp("y/Y", "accept")),
+			Reject: key.NewBinding(key.WithKeys("n", "N"), key.WithHelp("n/N", "reject")),
 		},
 	}
 }


### PR DESCRIPTION
  This patch:

-  introduces two new key bindings for the Confirm field
    * Accept  - The key bindings "y/Y" for accepting 
    * Reject - The key bindings  "n/N" for rejecting 

    have been added to the `ConfirmKeyMap` structure in keymap.go file. 

    ref: https://github.com/charmbracelet/gum/issues/568

- Centers Yes and No buttons
    
    ref: https://github.com/charmbracelet/gum/issues/566