### PR TITLE
fix(dynamic): enable form options with any generic type

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -77,7 +77,13 @@ type updateSuggestionsMsg struct {
 	suggestions []string
 }
 
+type isUpdateOptionsMsg interface {
+	IsUpdateOptionsMsg()
+}
+
 type updateOptionsMsg[T comparable] struct {
+	isUpdateOptionsMsg
+
 	id      int
 	hash    uint64
 	options []Option[T]

--- a/group.go
+++ b/group.go
@@ -253,7 +253,7 @@ func (g *Group) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			updateTitleMsg,
 			updateDescriptionMsg,
 			updateSuggestionsMsg,
-			updateOptionsMsg[string],
+			isUpdateOptionsMsg,
 			updatePlaceholderMsg:
 			m, cmd := g.fields[i].Update(msg)
 			g.fields[i] = m.(Field)


### PR DESCRIPTION
Hi! PR #233 introduced dynamic options to be used in forms and initially I was unable to get the following example working:

```go
	var workspaceId, folderId int
	form := huh.NewForm(
		huh.NewGroup(
			huh.NewSelect[int]().
				Title("Choose your workspace").
				Height(15).
				Options(options...). // initial options constructed from API call
				Value(&workspaceId),
			huh.NewSelect[int]().
				Value(&folderId).
				Title("Choose your folder").
				Height(5).
				OptionsFunc(func() (options []huh.Option[int]) {
					if workspaceId == 0 {
						return
					}
					// API call using workspace ID to fetch list of folder ids
					return
				}, &workspaceId),
			huh.NewConfirm().
				Title("Use selected?").
				Value(&proceed),
		),
	)
```

but I was able to get the examples included in the PR working. Digging further I was able to get my example working using `huh.Option[string]` and the issue ended up being this particular type switch not matching the generic type `huh.Option[int]`:

https://github.com/charmbracelet/huh/blob/ccca06d54254036ee839c17e21a38560efc523a8/group.go#L251-L261

I tried bumping the project to Go 1.20 and adding `UpdateOptionsMsg[any]` to the switch case, but that didn't work, so instead I made the `isUpdateOptionsMsg` interface and embedded it in `UpdateOptionsMsg`. I'm unsure if this is the best approach but it does seem to work and I couldn't find in my searching if there is a more intended way to solve this in Go.