### PR TITLE
fix: set YOffset + cursor based on first selected item

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -127,17 +127,24 @@ func (m *MultiSelect[T]) Options(options ...Option[T]) *MultiSelect[T] {
 		return m
 	}
 
+	minSelected := len(options) - 1
 	for i, o := range options {
-		for _, v := range m.accessor.Get() {
-			if o.Value == v {
-				options[i].selected = true
-				break
+		if o.selected {
+			options[i].selected = true
+			if i < minSelected {
+				minSelected = i
 			}
+			break
 		}
+	}
+	// No selected items... Start cursor at the beginning.
+	if minSelected == len(options)-1 {
+		minSelected = 0
 	}
 	m.options.val = options
 	m.filteredOptions = options
 	m.updateViewportHeight()
+	m.cursor = minSelected
 	return m
 }
 
@@ -549,11 +556,20 @@ func (m *MultiSelect[T]) optionsView() string {
 	return sb.String()
 }
 
+// centerYOffsetToSelected sets the YOffset so the selected element is in the
+// middle of the list.
+func (m *MultiSelect[T]) centerYOffsetToSelected() {
+	if m.cursor > m.viewport.YOffset+m.viewport.Height {
+		// Start with the selected value in the middle of the viewport.
+		m.viewport.SetYOffset(m.cursor - (m.viewport.Height+m.viewport.YOffset)/2)
+	}
+}
+
 // View renders the multi-select field.
 func (m *MultiSelect[T]) View() string {
 	styles := m.activeStyles()
-
 	m.viewport.SetContent(m.optionsView())
+	m.centerYOffsetToSelected()
 
 	var sb strings.Builder
 	if m.title.val != "" || m.title.fn != nil {

--- a/field_select.go
+++ b/field_select.go
@@ -588,10 +588,20 @@ func (s *Select[T]) optionsView() string {
 	return sb.String()
 }
 
+// centerYOffsetToSelected sets the YOffset so the selected element is in the
+// middle of the list.
+func (s *Select[T]) centerYOffsetToSelected() {
+	if s.selected > s.viewport.YOffset+s.viewport.Height {
+		// Start with the selected value in the middle of the viewport.
+		s.viewport.SetYOffset(s.selected - (s.viewport.Height+s.viewport.YOffset)/2)
+	}
+}
+
 // View renders the select field.
 func (s *Select[T]) View() string {
 	styles := s.activeStyles()
 	s.viewport.SetContent(s.optionsView())
+	s.centerYOffsetToSelected()
 
 	var sb strings.Builder
 	if s.title.val != "" || s.title.fn != nil {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b4eef94f-f809-469d-a2de-ac0007c7b558)
tested against gum @ `main-huh` (basically just made it depend on this branch of huh)
![image](https://github.com/user-attachments/assets/c76dcaa5-bfa9-4c07-9aed-051fcb53b081)

examples all work normally

you can test with Gum (after a lil go get -u github.com/charmbracelet/huh@refactor-select) then try seq 22 | go run .  choose --selected=2,21 --limit=2 (or set limit to one or none for single select)