### PR TITLE
refactor: select and multi select fields

### DIFF
--- a/examples/burger/main.go
+++ b/examples/burger/main.go
@@ -51,7 +51,7 @@ type Burger struct {
 
 func main() {
 	var burger Burger
-	var order = Order{Burger: burger}
+	order := Order{Burger: burger}
 
 	// Should we run in accessible mode?
 	accessible, _ := strconv.ParseBool(os.Getenv("ACCESSIBLE"))
@@ -83,13 +83,13 @@ func main() {
 				Title("Toppings").
 				Description("Choose up to 4.").
 				Options(
-					huh.NewOption("Lettuce", "Lettuce").Selected(true),
-					huh.NewOption("Tomatoes", "Tomatoes").Selected(true),
-					huh.NewOption("Charm Sauce", "Charm Sauce"),
-					huh.NewOption("Jalapeños", "Jalapeños"),
-					huh.NewOption("Cheese", "Cheese"),
-					huh.NewOption("Vegan Cheese", "Vegan Cheese"),
-					huh.NewOption("Nutella", "Nutella"),
+					huh.NewOption("Lettuce").Selected(true),
+					huh.NewOption("Tomatoes").Selected(true),
+					huh.NewOption("Charm Sauce"),
+					huh.NewOption("Jalapeños"),
+					huh.NewOption("Cheese"),
+					huh.NewOption("Vegan Cheese"),
+					huh.NewOption("Nutella"),
 				).
 				Validate(func(t []string) error {
 					if len(t) <= 0 {
@@ -152,7 +152,6 @@ func main() {
 	).WithAccessible(accessible)
 
 	err := form.Run()
-
 	if err != nil {
 		fmt.Println("Uh oh:", err)
 		os.Exit(1)

--- a/examples/burger/main.go
+++ b/examples/burger/main.go
@@ -83,13 +83,13 @@ func main() {
 				Title("Toppings").
 				Description("Choose up to 4.").
 				Options(
-					huh.NewOption("Lettuce").Selected(true),
-					huh.NewOption("Tomatoes").Selected(true),
-					huh.NewOption("Charm Sauce"),
-					huh.NewOption("Jalapeños"),
-					huh.NewOption("Cheese"),
-					huh.NewOption("Vegan Cheese"),
-					huh.NewOption("Nutella"),
+					huh.NewOption("Lettuce", "Lettuce").Selected(true),
+					huh.NewOption("Tomatoes", "Tomatoes").Selected(true),
+					huh.NewOption("Charm Sauce", "Charm Sauce"),
+					huh.NewOption("Jalapeños", "Jalapeños"),
+					huh.NewOption("Cheese", "Cheese"),
+					huh.NewOption("Vegan Cheese", "Vegan Cheese"),
+					huh.NewOption("Nutella", "Nutella"),
 				).
 				Validate(func(t []string) error {
 					if len(t) <= 0 {

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -25,6 +25,8 @@ const (
 	halfDown
 )
 
+const defaultLimit = 2
+
 // MultiSelect is a form multi-select field.
 type MultiSelect[T comparable] struct {
 	accessor Accessor[[]T]
@@ -79,6 +81,7 @@ func NewMultiSelect[T comparable]() *MultiSelect[T] {
 		description: Eval[string]{cache: make(map[uint64]string)},
 		spinner:     s,
 		selected:    make(map[int]Option[T]),
+		limit:       defaultLimit,
 	}
 }
 

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -51,7 +51,7 @@ type MultiSelect[T comparable] struct {
 	filter    textinput.Model
 	viewport  viewport.Model
 	spinner   spinner.Model
-	// avoid iterating over options to figure out what is selectedIndices.
+	// avoid iterating over options to figure out what is selected.
 	selected map[int]Option[T]
 
 	// options
@@ -339,13 +339,11 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.filtering && msg.String() == "k" {
 				break
 			}
-
 			m.moveCursor(up)
 		case key.Matches(msg, m.keymap.Down):
 			if m.filtering && msg.String() == "j" {
 				break
 			}
-
 			m.moveCursor(down)
 		case key.Matches(msg, m.keymap.GotoTop):
 			if m.filtering {

--- a/field_select.go
+++ b/field_select.go
@@ -183,7 +183,6 @@ func (s *Select[T]) Options(options ...Option[T]) *Select[T] {
 			s.ToggleSelect(i)
 		}
 	}
-
 	s.updateViewportHeight()
 	s.updateValue()
 
@@ -494,7 +493,6 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if len(s.filteredOptions) > 0 {
 				s.selected = min(s.selected, len(s.filteredOptions)-1)
-				s.viewport.SetYOffset(clamp(s.selected, 0, len(s.filteredOptions)-s.viewport.Height))
 			}
 		}
 	}
@@ -599,8 +597,8 @@ func (s *Select[T]) optionsView() string {
 
 // startAtSelected makes the viewport content start at the selected element.
 func (s *Select[T]) startAtSelected() {
-	if s.selected > s.viewport.Height {
-		s.viewport.SetYOffset(s.selected)
+	if s.selected > s.viewport.YOffset+s.viewport.Height {
+		s.viewport.SetYOffset(s.selected - s.viewport.YOffset)
 	}
 }
 

--- a/field_select.go
+++ b/field_select.go
@@ -309,11 +309,6 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	if s.filtering {
 		s.filter, cmd = s.filter.Update(msg)
-
-		// Keep the selected item in view.
-		if s.selected < s.viewport.YOffset || s.selected >= s.viewport.YOffset+s.viewport.Height {
-			s.viewport.SetYOffset(s.selected)
-		}
 	}
 
 	switch msg := msg.(type) {
@@ -588,10 +583,18 @@ func (s *Select[T]) optionsView() string {
 	return sb.String()
 }
 
+// startAtSelected makes the viewport content start at the selected element.
+func (s *Select[T]) startAtSelected() {
+	if s.selected > s.viewport.Height {
+		s.viewport.SetYOffset(s.selected)
+	}
+}
+
 // View renders the select field.
 func (s *Select[T]) View() string {
 	styles := s.activeStyles()
 	s.viewport.SetContent(s.optionsView())
+	s.startAtSelected()
 
 	var sb strings.Builder
 	if s.title.val != "" || s.title.fn != nil {

--- a/form.go
+++ b/form.go
@@ -60,12 +60,9 @@ var ErrTimeoutUnsupported = errors.New("timeout is not supported in accessible m
 // complete.
 type Form struct {
 	// collection of groups
-	groups []*Group
+	selector *selector.Selector[*Group]
 
 	results map[string]any
-
-	// navigation
-	selector *selector.Selector
 
 	// callbacks
 	SubmitCmd tea.Cmd
@@ -97,10 +94,9 @@ type Form struct {
 // Use With* methods to customize the form with options, such as setting
 // different themes and keybindings.
 func NewForm(groups ...*Group) *Form {
-	selector := selector.NewSelector(len(groups))
+	selector := selector.NewSelector(groups)
 
 	f := &Form{
-		groups:   groups,
 		selector: selector,
 		keymap:   NewDefaultKeyMap(),
 		results:  make(map[string]any),
@@ -235,9 +231,10 @@ func (f *Form) WithAccessible(accessible bool) *Form {
 // This allows the form groups and field to show what keybindings are available
 // to the user.
 func (f *Form) WithShowHelp(v bool) *Form {
-	for _, group := range f.groups {
+	f.selector.Range(func(_ int, group *Group) bool {
 		group.WithShowHelp(v)
-	}
+		return true
+	})
 	return f
 }
 
@@ -246,9 +243,10 @@ func (f *Form) WithShowHelp(v bool) *Form {
 // This allows the form groups and fields to show errors when the Validate
 // function returns an error.
 func (f *Form) WithShowErrors(v bool) *Form {
-	for _, group := range f.groups {
+	f.selector.Range(func(_ int, group *Group) bool {
 		group.WithShowErrors(v)
-	}
+		return true
+	})
 	return f
 }
 
@@ -261,9 +259,10 @@ func (f *Form) WithTheme(theme *Theme) *Form {
 	if theme == nil {
 		return f
 	}
-	for _, group := range f.groups {
+	f.selector.Range(func(_ int, group *Group) bool {
 		group.WithTheme(theme)
-	}
+		return true
+	})
 	return f
 }
 
@@ -275,9 +274,10 @@ func (f *Form) WithKeyMap(keymap *KeyMap) *Form {
 		return f
 	}
 	f.keymap = keymap
-	for _, group := range f.groups {
+	f.selector.Range(func(_ int, group *Group) bool {
 		group.WithKeyMap(keymap)
-	}
+		return true
+	})
 	f.UpdateFieldPositions()
 	return f
 }
@@ -292,10 +292,11 @@ func (f *Form) WithWidth(width int) *Form {
 		return f
 	}
 	f.width = width
-	for _, group := range f.groups {
+	f.selector.Range(func(_ int, group *Group) bool {
 		width := f.layout.GroupWidth(f, group, width)
 		group.WithWidth(width)
-	}
+		return true
+	})
 	return f
 }
 
@@ -305,9 +306,10 @@ func (f *Form) WithHeight(height int) *Form {
 		return f
 	}
 	f.height = height
-	for _, group := range f.groups {
+	f.selector.Range(func(_ int, group *Group) bool {
 		group.WithHeight(height)
-	}
+		return true
+	})
 	return f
 }
 
@@ -346,44 +348,48 @@ func (f *Form) WithLayout(layout Layout) *Form {
 // UpdateFieldPositions sets the position on all the fields.
 func (f *Form) UpdateFieldPositions() *Form {
 	firstGroup := 0
-	lastGroup := len(f.groups) - 1
+	lastGroup := f.selector.Total() - 1
 
 	// determine the first non-hidden group.
-	for g := range f.groups {
+	f.selector.Range(func(_ int, g *Group) bool {
 		if !f.isGroupHidden(g) {
-			break
+			return false
 		}
 		firstGroup++
-	}
+		return true
+	})
 
 	// determine the last non-hidden group.
-	for g := len(f.groups) - 1; g > 0; g-- {
+	f.selector.ReverseRange(func(_ int, g *Group) bool {
 		if !f.isGroupHidden(g) {
-			break
+			return false
 		}
 		lastGroup--
-	}
+		return true
+	})
 
-	for g, group := range f.groups {
+	f.selector.Range(func(g int, group *Group) bool {
 		// determine the first non-skippable field.
 		var firstField int
-		for _, field := range group.fields {
-			if !field.Skip() || len(group.fields) == 1 {
-				break
+		group.selector.Range(func(_ int, field Field) bool {
+			if !field.Skip() || group.selector.Total() == 1 {
+				return false
 			}
 			firstField++
-		}
+			return true
+		})
 
 		// determine the last non-skippable field.
 		var lastField int
-		for i := len(group.fields) - 1; i > 0; i-- {
+		group.selector.ReverseRange(func(i int, field Field) bool {
 			lastField = i
-			if !group.fields[i].Skip() || len(group.fields) == 1 {
-				break
+			if !field.Skip() || group.selector.Total() == 1 {
+				return false
 			}
-		}
+			return true
+		})
 
-		for i, field := range group.fields {
+		group.selector.Range(func(i int, field Field) bool {
 			field.WithPosition(FieldPosition{
 				Group:      g,
 				Field:      i,
@@ -392,25 +398,28 @@ func (f *Form) UpdateFieldPositions() *Form {
 				FirstGroup: firstGroup,
 				LastGroup:  lastGroup,
 			})
-		}
-	}
+			return true
+		})
+
+		return true
+	})
 	return f
 }
 
 // Errors returns the current groups' errors.
 func (f *Form) Errors() []error {
-	return f.groups[f.selector.Selected()].Errors()
+	return f.selector.Selected().Errors()
 }
 
 // Help returns the current groups' help.
 func (f *Form) Help() help.Model {
-	return f.groups[f.selector.Selected()].help
+	return f.selector.Selected().help
 }
 
 // KeyBinds returns the current fields' keybinds.
 func (f *Form) KeyBinds() []key.Binding {
-	group := f.groups[f.selector.Selected()]
-	return group.fields[f.selector.Selected()].KeyBinds()
+	group := f.selector.Selected()
+	return group.selector.Selected().KeyBinds()
 }
 
 // Get returns a result from the form.
@@ -471,13 +480,14 @@ func (f *Form) PrevField() tea.Cmd {
 
 // Init initializes the form.
 func (f *Form) Init() tea.Cmd {
-	cmds := make([]tea.Cmd, len(f.groups))
-	for i, group := range f.groups {
+	cmds := make([]tea.Cmd, f.selector.Total())
+	f.selector.Range(func(i int, group *Group) bool {
 		if i == 0 {
 			group.active = true
 		}
 		cmds[i] = group.Init()
-	}
+		return true
+	})
 
 	if f.isGroupHidden(f.selector.Selected()) {
 		cmds = append(cmds, nextGroup)
@@ -493,26 +503,27 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return f, nil
 	}
 
-	page := f.selector.Selected()
-	group := f.groups[page]
+	group := f.selector.Selected()
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		if f.width > 0 {
 			break
 		}
-		for _, group := range f.groups {
+		f.selector.Range(func(_ int, group *Group) bool {
 			width := f.layout.GroupWidth(f, group, msg.Width)
 			group.WithWidth(width)
-		}
+			return true
+		})
 		if f.height > 0 {
 			break
 		}
-		for _, group := range f.groups {
+		f.selector.Range(func(_ int, group *Group) bool {
 			if group.fullHeight() > msg.Height {
 				group.WithHeight(msg.Height)
 			}
-		}
+			return true
+		})
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, f.keymap.Quit):
@@ -524,10 +535,8 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case nextFieldMsg:
 		// Form is progressing to the next field, let's save the value of the current field.
-		if selected := group.selector.Selected(); selected < len(group.fields) {
-			field := group.fields[selected]
-			f.results[field.GetKey()] = field.GetValue()
-		}
+		field := group.selector.Selected()
+		f.results[field.GetKey()] = field.GetValue()
 
 	case nextGroupMsg:
 		if len(group.Errors()) > 0 {
@@ -544,9 +553,9 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return submit()
 		}
 
-		for i := f.selector.Selected() + 1; i < f.selector.Total(); i++ {
-			if !f.isGroupHidden(i) {
-				f.selector.SetSelected(i)
+		for i := f.selector.Index() + 1; i < f.selector.Total(); i++ {
+			if !f.isGroupHidden(f.selector.Get(i)) {
+				f.selector.SetIndex(i)
 				break
 			}
 			// all subsequent groups are hidden, so we must act as
@@ -555,27 +564,27 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return submit()
 			}
 		}
-		f.groups[f.selector.Selected()].active = true
-		return f, f.groups[f.selector.Selected()].Init()
+		f.selector.Selected().active = true
+		return f, f.selector.Selected().Init()
 
 	case prevGroupMsg:
 		if len(group.Errors()) > 0 {
 			return f, nil
 		}
 
-		for i := f.selector.Selected() - 1; i >= 0; i-- {
-			if !f.isGroupHidden(i) {
-				f.selector.SetSelected(i)
+		for i := f.selector.Index() - 1; i >= 0; i-- {
+			if !f.isGroupHidden(f.selector.Get(i)) {
+				f.selector.SetIndex(i)
 				break
 			}
 		}
 
-		f.groups[f.selector.Selected()].active = true
-		return f, f.groups[f.selector.Selected()].Init()
+		f.selector.Selected().active = true
+		return f, f.selector.Selected().Init()
 	}
 
 	m, cmd := group.Update(msg)
-	f.groups[page] = m.(*Group)
+	f.selector.Set(f.selector.Index(), m.(*Group))
 
 	// A user input a key, this could hide or show other groups,
 	// let's update all of their positions.
@@ -587,8 +596,8 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return f, cmd
 }
 
-func (f *Form) isGroupHidden(page int) bool {
-	hide := f.groups[page].hide
+func (f *Form) isGroupHidden(group *Group) bool {
+	hide := group.hide
 	if hide == nil {
 		return false
 	}
@@ -614,7 +623,7 @@ func (f *Form) RunWithContext(ctx context.Context) error {
 	f.SubmitCmd = tea.Quit
 	f.CancelCmd = tea.Quit
 
-	if len(f.groups) == 0 {
+	if f.selector.Total() == 0 {
 		return nil
 	}
 
@@ -652,13 +661,15 @@ func (f *Form) runAccessible() error {
 		return ErrTimeoutUnsupported
 	}
 
-	for _, group := range f.groups {
-		for _, field := range group.fields {
+	f.selector.Range(func(_ int, group *Group) bool {
+		group.selector.Range(func(_ int, field Field) bool {
 			field.Init()
 			field.Focus()
 			_ = field.WithAccessible(true).Run()
-		}
-	}
+			return true
+		})
+		return true
+	})
 
 	return nil
 }

--- a/form.go
+++ b/form.go
@@ -436,7 +436,7 @@ func (f *Form) GetString(key string) string {
 	return v
 }
 
-// GetInt returns a result as a string from the form.
+// GetInt returns a result as a int from the form.
 func (f *Form) GetInt(key string) int {
 	v, ok := f.results[key].(int)
 	if !ok {

--- a/huh_test.go
+++ b/huh_test.go
@@ -65,12 +65,12 @@ func TestForm(t *testing.T) {
 				Title("Toppings").
 				Description("Choose up to 4.").
 				Options(
-					NewOption("Lettuce").Selected(true),
-					NewOption("Tomatoes").Selected(true),
-					NewOption("Corn"),
-					NewOption("Salsa"),
-					NewOption("Sour Cream"),
-					NewOption("Cheese"),
+					NewOption("Lettuce", "lettuce").Selected(true),
+					NewOption("Tomatoes", "tomatoes").Selected(true),
+					NewOption("Corn", "corn"),
+					NewOption("Salsa", "salsa"),
+					NewOption("Sour Cream", "sour cream"),
+					NewOption("Cheese", "cheese"),
 				).
 				Validate(func(t []string) error {
 					if len(t) <= 0 {

--- a/huh_test.go
+++ b/huh_test.go
@@ -65,12 +65,12 @@ func TestForm(t *testing.T) {
 				Title("Toppings").
 				Description("Choose up to 4.").
 				Options(
-					NewOption("Lettuce", "lettuce").Selected(true),
-					NewOption("Tomatoes", "tomatoes").Selected(true),
-					NewOption("Corn", "corn"),
-					NewOption("Salsa", "salsa"),
-					NewOption("Sour Cream", "sour cream"),
-					NewOption("Cheese", "cheese"),
+					NewOption("Lettuce").Selected(true),
+					NewOption("Tomatoes").Selected(true),
+					NewOption("Corn"),
+					NewOption("Salsa"),
+					NewOption("Sour Cream"),
+					NewOption("Cheese"),
 				).
 				Validate(func(t []string) error {
 					if len(t) <= 0 {

--- a/internal/selector/selector.go
+++ b/internal/selector/selector.go
@@ -1,0 +1,56 @@
+package selector
+
+// Selector is a helper type for selecting items.
+type Selector struct {
+	index          int
+	numberOfFields int
+}
+
+// NewSelector creates a new item selector.
+func NewSelector(n int) *Selector {
+	return &Selector{
+		numberOfFields: n,
+	}
+}
+
+// Next moves the selector to the next item.
+func (s *Selector) Next() {
+	if s.index < s.numberOfFields-1 {
+		s.index++
+	}
+}
+
+// Prev moves the selector to the previous item.
+func (s *Selector) Prev() {
+	if s.index > 0 {
+		s.index--
+	}
+}
+
+// OnFirst returns true if the selector is on the first item.
+func (s *Selector) OnFirst() bool {
+	return s.index == 0
+}
+
+// OnLast returns true if the selector is on the last item.
+func (s *Selector) OnLast() bool {
+	return s.index == s.numberOfFields-1
+}
+
+// Selected returns the index of the current selected item.
+func (s *Selector) Selected() int {
+	return s.index
+}
+
+// Totoal returns the total number of items.
+func (s *Selector) Total() int {
+	return s.numberOfFields
+}
+
+// SetSelected sets the selected item.
+func (s *Selector) SetSelected(i int) {
+	if i < 0 || i >= s.numberOfFields {
+		return
+	}
+	s.index = i
+}

--- a/internal/selector/selector.go
+++ b/internal/selector/selector.go
@@ -1,56 +1,96 @@
 package selector
 
 // Selector is a helper type for selecting items.
-type Selector struct {
-	index          int
-	numberOfFields int
+type Selector[T any] struct {
+	items []T
+	index int
 }
 
 // NewSelector creates a new item selector.
-func NewSelector(n int) *Selector {
-	return &Selector{
-		numberOfFields: n,
+func NewSelector[T any](items []T) *Selector[T] {
+	return &Selector[T]{
+		items: items,
 	}
 }
 
+// Append adds an item to the selector.
+func (s *Selector[T]) Append(item T) {
+	s.items = append(s.items, item)
+}
+
 // Next moves the selector to the next item.
-func (s *Selector) Next() {
-	if s.index < s.numberOfFields-1 {
+func (s *Selector[T]) Next() {
+	if s.index < len(s.items)-1 {
 		s.index++
 	}
 }
 
 // Prev moves the selector to the previous item.
-func (s *Selector) Prev() {
+func (s *Selector[T]) Prev() {
 	if s.index > 0 {
 		s.index--
 	}
 }
 
 // OnFirst returns true if the selector is on the first item.
-func (s *Selector) OnFirst() bool {
+func (s *Selector[T]) OnFirst() bool {
 	return s.index == 0
 }
 
 // OnLast returns true if the selector is on the last item.
-func (s *Selector) OnLast() bool {
-	return s.index == s.numberOfFields-1
+func (s *Selector[T]) OnLast() bool {
+	return s.index == len(s.items)-1
 }
 
 // Selected returns the index of the current selected item.
-func (s *Selector) Selected() int {
+func (s *Selector[T]) Selected() T {
+	return s.items[s.index]
+}
+
+// Index returns the index of the current selected item.
+func (s *Selector[T]) Index() int {
 	return s.index
 }
 
 // Totoal returns the total number of items.
-func (s *Selector) Total() int {
-	return s.numberOfFields
+func (s *Selector[T]) Total() int {
+	return len(s.items)
 }
 
-// SetSelected sets the selected item.
-func (s *Selector) SetSelected(i int) {
-	if i < 0 || i >= s.numberOfFields {
+// SetIndex sets the selected item.
+func (s *Selector[T]) SetIndex(i int) {
+	if i < 0 || i >= len(s.items) {
 		return
 	}
 	s.index = i
+}
+
+// Get returns the item at the given index.
+func (s *Selector[T]) Get(i int) T {
+	return s.items[i]
+}
+
+// Set sets the item at the given index.
+func (s *Selector[T]) Set(i int, item T) {
+	s.items[i] = item
+}
+
+// Range iterates over the items.
+// The callback function should return true to continue the iteration.
+func (s *Selector[T]) Range(f func(i int, item T) bool) {
+	for i, item := range s.items {
+		if !f(i, item) {
+			break
+		}
+	}
+}
+
+// ReverseRange iterates over the items in reverse.
+// The callback function should return true to continue the iteration.
+func (s *Selector[T]) ReverseRange(f func(i int, item T) bool) {
+	for i := len(s.items) - 1; i >= 0; i-- {
+		if !f(i, s.items[i]) {
+			break
+		}
+	}
 }

--- a/layout.go
+++ b/layout.go
@@ -31,7 +31,7 @@ func LayoutGrid(rows int, columns int) Layout {
 type layoutDefault struct{}
 
 func (l *layoutDefault) View(f *Form) string {
-	return f.groups[f.paginator.Page].View()
+	return f.groups[f.selector.Selected()].View()
 }
 
 func (l *layoutDefault) GroupWidth(_ *Form, _ *Group, w int) int {
@@ -43,7 +43,7 @@ type layoutColumns struct {
 }
 
 func (l *layoutColumns) visibleGroups(f *Form) []*Group {
-	segmentIndex := f.paginator.Page / l.columns
+	segmentIndex := f.selector.Selected() / l.columns
 	start := segmentIndex * l.columns
 	end := start + l.columns
 
@@ -64,7 +64,7 @@ func (l *layoutColumns) View(f *Form) string {
 	for _, group := range groups {
 		columns = append(columns, group.Content())
 	}
-	footer := f.groups[f.paginator.Page].Footer()
+	footer := f.groups[f.selector.Selected()].Footer()
 
 	return lipgloss.JoinVertical(lipgloss.Left,
 		lipgloss.JoinHorizontal(lipgloss.Top, columns...),
@@ -83,7 +83,7 @@ func (l *layoutStack) View(f *Form) string {
 	for _, group := range f.groups {
 		columns = append(columns, group.Content())
 	}
-	footer := f.groups[f.paginator.Page].Footer()
+	footer := f.groups[f.selector.Selected()].Footer()
 
 	var view strings.Builder
 	view.WriteString(strings.Join(columns, "\n"))
@@ -101,7 +101,7 @@ type layoutGrid struct {
 
 func (l *layoutGrid) visibleGroups(f *Form) [][]*Group {
 	total := l.rows * l.columns
-	segmentIndex := f.paginator.Page / total
+	segmentIndex := f.selector.Selected() / total
 	start := segmentIndex * total
 	end := start + total
 
@@ -139,7 +139,7 @@ func (l *layoutGrid) View(f *Form) string {
 		}
 		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, columns...))
 	}
-	footer := f.groups[f.paginator.Page].Footer()
+	footer := f.groups[f.selector.Selected()].Footer()
 
 	return lipgloss.JoinVertical(lipgloss.Left, strings.Join(rows, "\n"), footer)
 }

--- a/layout.go
+++ b/layout.go
@@ -31,7 +31,7 @@ func LayoutGrid(rows int, columns int) Layout {
 type layoutDefault struct{}
 
 func (l *layoutDefault) View(f *Form) string {
-	return f.groups[f.selector.Selected()].View()
+	return f.selector.Selected().View()
 }
 
 func (l *layoutDefault) GroupWidth(_ *Form, _ *Group, w int) int {
@@ -43,15 +43,25 @@ type layoutColumns struct {
 }
 
 func (l *layoutColumns) visibleGroups(f *Form) []*Group {
-	segmentIndex := f.selector.Selected() / l.columns
+	segmentIndex := f.selector.Index() / l.columns
 	start := segmentIndex * l.columns
 	end := start + l.columns
 
-	if end > len(f.groups) {
-		end = len(f.groups)
+	total := f.selector.Total()
+	if end > total {
+		end = total
 	}
 
-	return f.groups[start:end]
+	var groups []*Group
+	f.selector.Range(func(i int, group *Group) bool {
+		if i >= start && i < end {
+			groups = append(groups, group)
+			return true
+		}
+		return false
+	})
+
+	return groups
 }
 
 func (l *layoutColumns) View(f *Form) string {
@@ -64,7 +74,7 @@ func (l *layoutColumns) View(f *Form) string {
 	for _, group := range groups {
 		columns = append(columns, group.Content())
 	}
-	footer := f.groups[f.selector.Selected()].Footer()
+	footer := f.selector.Selected().Footer()
 
 	return lipgloss.JoinVertical(lipgloss.Left,
 		lipgloss.JoinHorizontal(lipgloss.Top, columns...),
@@ -80,10 +90,11 @@ type layoutStack struct{}
 
 func (l *layoutStack) View(f *Form) string {
 	var columns []string
-	for _, group := range f.groups {
+	f.selector.Range(func(_ int, group *Group) bool {
 		columns = append(columns, group.Content())
-	}
-	footer := f.groups[f.selector.Selected()].Footer()
+		return true
+	})
+	footer := f.selector.Selected().Footer()
 
 	var view strings.Builder
 	view.WriteString(strings.Join(columns, "\n"))
@@ -101,15 +112,22 @@ type layoutGrid struct {
 
 func (l *layoutGrid) visibleGroups(f *Form) [][]*Group {
 	total := l.rows * l.columns
-	segmentIndex := f.selector.Selected() / total
+	segmentIndex := f.selector.Index() / total
 	start := segmentIndex * total
 	end := start + total
 
-	if end > len(f.groups) {
-		end = len(f.groups)
+	if glen := f.selector.Total(); end > glen {
+		end = glen
 	}
 
-	visible := f.groups[start:end]
+	var visible []*Group
+	f.selector.Range(func(i int, group *Group) bool {
+		if i >= start && i < end {
+			visible = append(visible, group)
+			return true
+		}
+		return false
+	})
 	grid := make([][]*Group, l.rows)
 	for i := 0; i < l.rows; i++ {
 		startRow := i * l.columns
@@ -139,7 +157,7 @@ func (l *layoutGrid) View(f *Form) string {
 		}
 		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, columns...))
 	}
-	footer := f.groups[f.selector.Selected()].Footer()
+	footer := f.selector.Selected().Footer()
 
 	return lipgloss.JoinVertical(lipgloss.Left, strings.Join(rows, "\n"), footer)
 }

--- a/option.go
+++ b/option.go
@@ -6,7 +6,8 @@ import (
 
 // Option is an option for select fields.
 type Option[T comparable] struct {
-	Value T
+	Value    T
+	selected bool
 }
 
 // NewOptions returns new options from a list of values.
@@ -18,6 +19,12 @@ func NewOptions[T comparable](values ...T) []Option[T] {
 		}
 	}
 	return options
+}
+
+// Selected sets whether the option is currently selected.
+func (o Option[T]) Selected(selected bool) Option[T] {
+	o.selected = selected
+	return o
 }
 
 // String returns the string representation of the Option.

--- a/option.go
+++ b/option.go
@@ -1,12 +1,12 @@
 package huh
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Option is an option for select fields.
 type Option[T comparable] struct {
-	Key      string
-	Value    T
-	selected bool
+	Value T
 }
 
 // NewOptions returns new options from a list of values.
@@ -14,25 +14,18 @@ func NewOptions[T comparable](values ...T) []Option[T] {
 	options := make([]Option[T], len(values))
 	for i, o := range values {
 		options[i] = Option[T]{
-			Key:   fmt.Sprint(o),
 			Value: o,
 		}
 	}
 	return options
 }
 
-// NewOption returns a new select option.
-func NewOption[T comparable](key string, value T) Option[T] {
-	return Option[T]{Key: key, Value: value}
-}
-
-// Selected sets whether the option is currently selected.
-func (o Option[T]) Selected(selected bool) Option[T] {
-	o.selected = selected
-	return o
-}
-
-// String returns the key of the option.
+// String returns the string representation of the Option.
 func (o Option[T]) String() string {
-	return o.Key
+	return fmt.Sprint(o.Value)
+}
+
+// NewOption returns a new select option.
+func NewOption[T comparable](value T) Option[T] {
+	return Option[T]{Value: value}
 }

--- a/option.go
+++ b/option.go
@@ -6,6 +6,7 @@ import (
 
 // Option is an option for select fields.
 type Option[T comparable] struct {
+	Key      string
 	Value    T
 	selected bool
 }
@@ -15,6 +16,7 @@ func NewOptions[T comparable](values ...T) []Option[T] {
 	options := make([]Option[T], len(values))
 	for i, o := range values {
 		options[i] = Option[T]{
+			Key:   fmt.Sprint(o),
 			Value: o,
 		}
 	}
@@ -29,10 +31,10 @@ func (o Option[T]) Selected(selected bool) Option[T] {
 
 // String returns the string representation of the Option.
 func (o Option[T]) String() string {
-	return fmt.Sprint(o.Value)
+	return o.Key
 }
 
 // NewOption returns a new select option.
-func NewOption[T comparable](value T) Option[T] {
-	return Option[T]{Value: value}
+func NewOption[T comparable](key string, value T) Option[T] {
+	return Option[T]{Key: key, Value: value}
 }


### PR DESCRIPTION
- **fix(SingleSelect): start at selected index**
- **refactor: track selected values in map**
- **wip: re-add selected field to option; broken examples due to API**
- **refactor: restore Key to Option, clean**

How to test:
- `go test ./... -v` in root dir
- run examples using `Select` and `MultiSelect` (burger, gum, theme, readme/multiselect)
- you can also test with Gum (after a lil `go get -u github.com/charmbracelet/huh@refactor-select`) then try `seq 22 | go run .  choose --selected=2,21 --limit=2` (or set limit to one or none for single select)

Behavioral Changes:
- the selections returned are not ordered