### PR TITLE
feat(multiselect): contextual 'select all' help text

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -259,12 +259,12 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case updateFieldMsg:
-		var cmds []tea.Cmd
+		var fieldCmds []tea.Cmd
 		if ok, hash := m.title.shouldUpdate(); ok {
 			m.title.bindingsHash = hash
 			if !m.title.loadFromCache() {
 				m.title.loading = true
-				cmds = append(cmds, func() tea.Msg {
+				fieldCmds = append(fieldCmds, func() tea.Msg {
 					return updateTitleMsg{id: m.id, title: m.title.fn(), hash: hash}
 				})
 			}
@@ -273,7 +273,7 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.description.bindingsHash = hash
 			if !m.description.loadFromCache() {
 				m.description.loading = true
-				cmds = append(cmds, func() tea.Msg {
+				fieldCmds = append(fieldCmds, func() tea.Msg {
 					return updateDescriptionMsg{id: m.id, description: m.description.fn(), hash: hash}
 				})
 			}
@@ -287,13 +287,13 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				m.options.loading = true
 				m.options.loadingStart = time.Now()
-				cmds = append(cmds, func() tea.Msg {
+				fieldCmds = append(fieldCmds, func() tea.Msg {
 					return updateOptionsMsg[T]{id: m.id, options: m.options.fn(), hash: hash}
 				}, m.spinner.Tick)
 			}
 		}
 
-		return m, tea.Batch(cmds...)
+		return m, tea.Batch(fieldCmds...)
 
 	case spinner.TickMsg:
 		if !m.options.loading {

--- a/keymap.go
+++ b/keymap.go
@@ -65,7 +65,8 @@ type MultiSelectKeyMap struct {
 	SetFilter    key.Binding
 	ClearFilter  key.Binding
 	Submit       key.Binding
-	ToggleAll    key.Binding
+	SelectAll    key.Binding
+	SelectNone   key.Binding
 }
 
 // FilePickerKey is the keybindings for filepicker fields.
@@ -165,7 +166,8 @@ func NewDefaultKeyMap() *KeyMap {
 			HalfPageDown: key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("ctrl+d", "½ page down")),
 			GotoTop:      key.NewBinding(key.WithKeys("home", "g"), key.WithHelp("g/home", "go to start")),
 			GotoBottom:   key.NewBinding(key.WithKeys("end", "G"), key.WithHelp("G/end", "go to end")),
-			ToggleAll:    key.NewBinding(key.WithKeys("ctrl+a"), key.WithHelp("ctrl+a", "toggle select all")),
+			SelectAll:    key.NewBinding(key.WithKeys("ctrl+a"), key.WithHelp("ctrl+a", "select all")),
+			SelectNone:   key.NewBinding(key.WithKeys("ctrl+a"), key.WithHelp("ctrl+a", "select none"), key.WithDisabled()),
 		},
 		Note: NoteKeyMap{
 			Prev:   key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "back")),


### PR DESCRIPTION
This revision changes the "toggle all" help text to "select all" and "select none" depending on what action will be performed.

https://github.com/user-attachments/assets/ca313b83-69a0-4931-9092-9e20eafd282f

Here's the source code for the above example:

```go
package main

import (
	"fmt"
	"os"

	"github.com/charmbracelet/huh"
)

func main() {
	prompt := huh.NewMultiSelect[int]().
		Title("Choose stuff, will ya?").
		Height(10).
		Options(
			huh.NewOption("Uno", 1),
			huh.NewOption("Due", 2),
			huh.NewOption("Tre", 3),
			huh.NewOption("Quattro", 4),
			huh.NewOption("Cinque", 5),
			huh.NewOption("Sei", 6),
			huh.NewOption("Sette", 7),
			huh.NewOption("Otto", 8),
			huh.NewOption("Nove", 9),
			huh.NewOption("Dieci", 10),
		)

	f := huh.NewForm(huh.NewGroup(prompt))

	if err := f.Run(); err != ni l {
		fmt.Fprint(os.Stderr, "Uh oh: ", err)
		os.Exit(1)
	}
}
```