### PR TITLE
feat(spinner): add Output method to expose overwriting the output

### DIFF
--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -90,6 +90,12 @@ func (s *Spinner) Accessible(accessible bool) *Spinner {
 	return s
 }
 
+// Output sets the output of the spinner.
+func (s *Spinner) Output(output *termenv.Output) *Spinner {
+	s.output = output
+	return s
+}
+
 // New creates a new spinner.
 func New() *Spinner {
 	s := spinner.New()
@@ -174,7 +180,7 @@ func (s *Spinner) runAccessible() error {
 	s.output.HideCursor()
 	frame := s.spinner.Style.Render("...")
 	title := s.titleStyle.Render(strings.TrimSuffix(s.title, "..."))
-	fmt.Println(title + frame)
+	fmt.Fprintln(s.output, title+frame)
 
 	if s.ctx == nil {
 		s.action()

--- a/spinner/spinner_test.go
+++ b/spinner/spinner_test.go
@@ -2,13 +2,18 @@ package spinner
 
 import (
 	"context"
+	"errors"
+	"io"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 func TestNewSpinner(t *testing.T) {
@@ -110,5 +115,88 @@ func TestAccessibleSpinner(t *testing.T) {
 	err := s.Run()
 	if err != nil {
 		t.Errorf("Run() in accessible mode returned an error: %v", err)
+	}
+}
+
+func TestSpinnerOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantStdout bool
+		wantStderr bool
+	}{
+		{
+			name:       "stdout",
+			wantStdout: true,
+			wantStderr: false,
+		},
+		{
+			name:       "stderr",
+			wantStdout: false,
+			wantStderr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const title = "Test Output"
+
+			// Save original stderr and stdout
+			oldStderr := os.Stderr
+			oldStdout := os.Stdout
+
+			// Create pipes for stderr and stdout
+			stderrReader, stderrWriter, _ := os.Pipe()
+			stdoutReader, stdoutWriter, _ := os.Pipe()
+
+			// Set global stderr and stdout to our pipes
+			os.Stderr = stderrWriter
+			os.Stdout = stdoutWriter
+
+			// Create a spinner and set its output
+			s := New().Title(title).Accessible(true)
+			if tc.wantStderr {
+				s.Output(termenv.NewOutput(os.Stderr))
+			}
+			if tc.wantStdout {
+				s.Output(termenv.NewOutput(os.Stdout))
+			}
+			s.action = func() { time.Sleep(100 * time.Millisecond) }
+			if err := s.Run(); err != nil {
+				t.Errorf("Spinner.Run() returned an error: %v", err)
+			}
+
+			// Restore original stderr and stdout
+			os.Stderr = oldStderr
+			os.Stdout = oldStdout
+
+			// Close the pipes
+			if err := errors.Join(stderrWriter.Close(), stdoutWriter.Close()); err != nil {
+				t.Errorf("Failed to close pipes: %v", err)
+			}
+
+			// Read from the pipes
+			stderrOutput, stderrErr := io.ReadAll(stderrReader)
+			stdoutOutput, stdoutErr := io.ReadAll(stdoutReader)
+			if err := errors.Join(stderrErr, stdoutErr); err != nil {
+				t.Errorf("Failed to read from pipes: %v", err)
+			}
+
+			// Check the output
+			if tc.wantStderr {
+				if !strings.Contains(string(stderrOutput), title) {
+					t.Errorf("Stderr got %q, but wanted %q", stderrOutput, title)
+				}
+				if len(stdoutOutput) > 0 {
+					t.Errorf("Expected no output on stdout, but got %q", stdoutOutput)
+				}
+			}
+			if tc.wantStdout {
+				if !strings.Contains(string(stdoutOutput), title) {
+					t.Errorf("Stdout got %q, but wanted %q", stdoutOutput, title)
+				}
+				if len(stderrOutput) > 0 {
+					t.Errorf("Expected no output on stderr, but got %q", stderrOutput)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This allows callers to override the output used and fixes a line where stdout was always used.

This only applies under Accessible mode (which seems to be the original intention), leaving the tea program writing to Stderr.

The reason for this is under some environments it may be preferable to have Accessible write to stderr - Our usecase is that the spinner produces some json output that is piped to `jq` in some automated environments, but also availble as a CLI for users.