### PR TITLE
feat: Add Cursor() methods to Select and MultiSelect fields

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -220,6 +220,17 @@ func (m *MultiSelect[T]) Blur() tea.Cmd {
 	return nil
 }
 
+// Hovered returns the value of the option under the cursor, and a bool
+// indicating whether one was found. If there are no visible options, returns
+// a zero-valued T and false.
+func (m *MultiSelect[T]) Hovered() (T, bool) {
+	if len(m.filteredOptions) == 0 || m.cursor >= len(m.filteredOptions) {
+		var zero T
+		return zero, false
+	}
+	return m.filteredOptions[m.cursor].Value, true
+}
+
 // KeyBinds returns the help message for the multi-select field.
 func (m *MultiSelect[T]) KeyBinds() []key.Binding {
 	binds := []key.Binding{

--- a/field_select.go
+++ b/field_select.go
@@ -281,6 +281,17 @@ func (s *Select[T]) Blur() tea.Cmd {
 	return nil
 }
 
+// Hovered returns the value of the option under the cursor, and a bool
+// indicating whether one was found. If there are no visible options, returns
+// a zero-valued T and false.
+func (m *Select[T]) Hovered() (T, bool) {
+	if len(m.filteredOptions) == 0 || m.selected >= len(m.filteredOptions) {
+		var zero T
+		return zero, false
+	}
+	return m.filteredOptions[m.selected].Value, true
+}
+
 // KeyBinds returns the help keybindings for the select field.
 func (s *Select[T]) KeyBinds() []key.Binding {
 	return []key.Binding{


### PR DESCRIPTION
Hi! This PR addresses a small limitation I ran into while building out a UI with this library. I was using a MultiSelect field to display a list of options, and wanted to use a Note to show additional details/context information for the option under the cursor. However, there was no way to know which option that was.

With this change, you can now write the following:

```go
items := []string{...}

ms := huh.NewMultiSelect[string]().
	Options(huh.NewOptions(items...)...)

huh.NewNote().
	DescriptionFunc(func() string {
		currentItem := items[ms.Cursor()]
		// do something with currentItem
	}, onCursorUpdate{ms}) // <- see below
```

There is still the small issue of knowing when to invalidate the DescriptionFunc - I solved this by using the value of `Cursor()` as a hash:

```go
type onCursorUpdate struct {
	Field interface{ Cursor() int }
}

// Hash implements hashstructure.Hashable
func (u onCursorUpdate) Hash() (uint64, error) {
	return uint64(u.Field.Cursor()), nil
}
```

This relies on implementation details however, so if this use case is common, something like it (but with a more idiomatic api) could be a good candidate for a built-in utility.
