### PR TITLE
feat: Adjust `Confirm Buttons` within the Confirm Field

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -30,24 +30,26 @@ type Confirm struct {
 	focused bool
 
 	// options
-	width      int
-	height     int
-	inline     bool
-	accessible bool
-	theme      *Theme
-	keymap     ConfirmKeyMap
+	width           int
+	height          int
+	inline          bool
+	accessible      bool
+	theme           *Theme
+	keymap          ConfirmKeyMap
+	buttonAlignment lipgloss.Position
 }
 
 // NewConfirm returns a new confirm field.
 func NewConfirm() *Confirm {
 	return &Confirm{
-		accessor:    &EmbeddedAccessor[bool]{},
-		id:          nextID(),
-		title:       Eval[string]{cache: make(map[uint64]string)},
-		description: Eval[string]{cache: make(map[uint64]string)},
-		affirmative: "Yes",
-		negative:    "No",
-		validate:    func(bool) error { return nil },
+		accessor:        &EmbeddedAccessor[bool]{},
+		id:              nextID(),
+		title:           Eval[string]{cache: make(map[uint64]string)},
+		description:     Eval[string]{cache: make(map[uint64]string)},
+		affirmative:     "Yes",
+		negative:        "No",
+		validate:        func(bool) error { return nil },
+		buttonAlignment: lipgloss.Center,
 	}
 }
 
@@ -268,7 +270,7 @@ func (c *Confirm) View() string {
 
 	c.keymap.Accept.SetHelp("y", c.affirmative)
 
-	buttonsRow := lipgloss.JoinHorizontal(lipgloss.Center, affirmative, negative)
+	buttonsRow := lipgloss.JoinHorizontal(c.buttonAlignment, affirmative, negative)
 
 	promptWidth := lipgloss.Width(sb.String())
 	buttonsWidth := lipgloss.Width(buttonsRow)
@@ -278,7 +280,7 @@ func (c *Confirm) View() string {
 		renderWidth = buttonsWidth
 	}
 
-	style := lipgloss.NewStyle().Width(renderWidth).Align(lipgloss.Center)
+	style := lipgloss.NewStyle().Width(renderWidth).Align(c.buttonAlignment)
 
 	sb.WriteString(style.Render(buttonsRow))
 	return styles.Base.Render(sb.String())
@@ -347,6 +349,11 @@ func (c *Confirm) WithPosition(p FieldPosition) Field {
 	c.keymap.Prev.SetEnabled(!p.IsFirst())
 	c.keymap.Next.SetEnabled(!p.IsLast())
 	c.keymap.Submit.SetEnabled(p.IsLast())
+	return c
+}
+
+func (c *Confirm) WithButtonAlignment(p lipgloss.Position) *Confirm {
+	c.buttonAlignment = p
 	return c
 }
 


### PR DESCRIPTION
## Changes

- Added in method to adjust the position of the confirm buttons, within the confirm field
- If the user does not adjust the position of the confirm buttons, it defaults to the center of the confirm view field
- If the user provides the position of the confirm buttons, it overrides the position of the buttons in the confirm view field

## Testing

Made some changes within `examples/git/main.go` to test out these changes

```diff
diff --git a/examples/git/main.go b/examples/git/main.go
index 06a94f9..3d1cab7 100644
--- a/examples/git/main.go
+++ b/examples/git/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // types is the possible commit types specified by the conventional commit spec.
@@ -12,19 +13,22 @@ var types = []string{"fix", "feat", "docs", "style", "refactor", "test", "chore"
 // And then prompts for the summary and detailed description of the message and
 // uses the values provided as the summary and details of the message.
 func main() {
-	var commit, scope string
-	var summary, description string
+	// var commit, scope string
+	// var summary, description string
 	var confirm bool
 
 	huh.NewForm(
-		huh.NewGroup(
-			huh.NewInput().Title("Type").Value(&commit).Placeholder("feat").Suggestions(types),
-			huh.NewInput().Title("Scope").Value(&scope).Placeholder("scope"),
-		),
-		huh.NewGroup(
-			huh.NewInput().Title("Summary").Value(&summary).Placeholder("Summary of changes"),
-			huh.NewText().Title("Description").Value(&description).Placeholder("Detailed description of changes"),
-		),
-		huh.NewGroup(huh.NewConfirm().Title("Commit changes?").Value(&confirm)),
+		// huh.NewGroup(
+		// 	huh.NewInput().Title("Type").Value(&commit).Placeholder("feat").Suggestions(types),
+		// 	huh.NewInput().Title("Scope").Value(&scope).Placeholder("scope"),
+		// ),
+		// huh.NewGroup(
+		// 	huh.NewInput().Title("Summary").Value(&summary).Placeholder("Summary of changes"),
+		// 	huh.NewText().Title("Description").Value(&description).Placeholder("Detailed description of changes"),
+		// ),
+		huh.NewGroup(huh.NewConfirm().Title("Commit changes?Commit changes?Commit changes?Commit changes?Commit changes?Commit changes?Commit changes?").Value(&confirm)),
+		huh.NewGroup(huh.NewConfirm().Title("Commit changes?Commit changes?").Value(&confirm)),
+		huh.NewGroup(huh.NewConfirm().WithButtonAlignment(lipgloss.Left).Title("Commit changes?Commit changes?Commit changes?Commit changes?Commit changes?Commit changes?Commit changes?").Value(&confirm)),
+		huh.NewGroup(huh.NewConfirm().WithButtonAlignment(lipgloss.Left).Title("Commit changes?Commit changes?").Value(&confirm)),
 	).Run()
 }

```
![image](https://github.com/user-attachments/assets/f40c32a0-d39c-40f8-ae42-5cf989609845)


Before: Confirm buttons would appear in the center of the confirm view field

(Long Title, with buttons aligned in the center)
![image](https://github.com/user-attachments/assets/f8eda9eb-637e-447b-bf86-b338eb7cb030)

(Short title, with buttons aligned in the center)
![image](https://github.com/user-attachments/assets/be3d83d8-1956-4319-830c-2137d84cc26e)


After: adding `withButtonAlignment(lipgloss.Left)`, confirm buttons appears on the left of the confirm view field

(Long Title, with buttons aligned in the left)
![image](https://github.com/user-attachments/assets/fbebdfa6-7bff-4251-a31a-61dfb80633c8)

(Short title, with buttons aligned in the left)
![image](https://github.com/user-attachments/assets/eb6cb9e5-8a0a-4522-a535-f898311fce62)

## Other Notes

- [x] Intends to Close https://github.com/charmbracelet/huh/issues/367
- [ ] Not sure how to write tests for it, looking for any indicators





