### PR TITLE
fix(confirm): Ensure validation occurs when moving within fields

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -204,14 +204,30 @@ func (c *Confirm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			c.accessor.Set(!c.accessor.Get())
 		case key.Matches(msg, c.keymap.Prev):
+			c.err = c.validate(c.accessor.Get())
+			if c.err != nil {
+				return c, nil
+			}
 			cmds = append(cmds, PrevField)
 		case key.Matches(msg, c.keymap.Next, c.keymap.Submit):
+			c.err = c.validate(c.accessor.Get())
+			if c.err != nil {
+				return c, nil
+			}
 			cmds = append(cmds, NextField)
 		case key.Matches(msg, c.keymap.Accept):
 			c.accessor.Set(true)
+			c.err = c.validate(c.accessor.Get())
+			if c.err != nil {
+				return c, nil
+			}
 			cmds = append(cmds, NextField)
 		case key.Matches(msg, c.keymap.Reject):
 			c.accessor.Set(false)
+			c.err = c.validate(c.accessor.Get())
+			if c.err != nil {
+				return c, nil
+			}
 			cmds = append(cmds, NextField)
 		}
 	}


### PR DESCRIPTION
## Changes

- Added in a fix to ensure that when the confirm field has a Validate method provided, it should validate the value, and does not move between different fields
- Previously when a user submits the confirm field, it would just move to the next field in the `huh.Group`, reason being that within the `Update()` method of `field_confirm`, the `NextField()` tea.Cmd would be used, but there was no checks/Validation taking place to see if it's allowed to move to the next field
- Hence now, if the user submits the confirm field, it ensures the Validate method is called, to see if the value is allowed, and then allow to move to the next field

## Testing Notes

```
package main

import (
	"errors"
	"fmt"

	"github.com/charmbracelet/huh"
)

func main() {
	var confirm bool
	var confirm2 bool

	huh.NewForm(
		huh.NewGroup(
			huh.NewConfirm().
				Title("Install ABC?").
				Value(&confirm).
				Validate(func(install bool) error {
					if !install {
						return errors.New("you have to install this")
					}
					return nil
				}),
			huh.NewConfirm().
				Title("Install XYZ?").
				Value(&confirm2).
				Validate(func(install bool) error {
					if !install {
						return errors.New("you have to install this")
					}
					return nil
				}),
		),
	).Run()

	fmt.Printf("confirm: %v confirm2: %v\n", confirm, confirm2)
}
```

Previously:

Rendering two confirm fields, which have validate
![image](https://github.com/user-attachments/assets/0ed7d07b-5e04-4132-afce-0f784af7a528)

Pressing `Enter` ends up moving the selection from the first field, to the second one (even though the validate function is called, but doesn't block from moving to the new field)

![image](https://github.com/user-attachments/assets/33683939-c41b-46eb-9639-a1563507d646)

Pressing `Enter` again ends up moving the selection the next field, but doesn't block from moving to the next field
![image](https://github.com/user-attachments/assets/379db28e-6aa8-4073-8c4a-9f0e0a78e7fb)


Now:

Rendering two confirm fields which have validate
![image](https://github.com/user-attachments/assets/9ced1ea2-39b9-44aa-bd69-823b473ea1e9)

Pressing `Enter` does not move the selection to the next field, and blocks it (due to the validate function)
![image](https://github.com/user-attachments/assets/b0f41943-3f0c-4c4b-baac-ca4a460ef787)

Pressing `Left`
![image](https://github.com/user-attachments/assets/3c1a1465-b75d-4d51-a0e3-759961140462)

Pressing `Enter` ends up moving the selection to the next field, since the validation passed
![image](https://github.com/user-attachments/assets/200bf8f7-1683-4eae-83b4-c88fd29fee10)

Pressing `Enter` again does not move the selection to the next field and blocks it (due to the validate function)
![image](https://github.com/user-attachments/assets/f0af802b-300a-4d4b-a353-c98dfb148ead)

Works as exepcted
![image](https://github.com/user-attachments/assets/07944acc-923d-4b57-a4e1-d2b9176bcffc)






## Other Notes

Related to: https://github.com/charmbracelet/huh/issues/417
- [ ] Anything else missing, What permutations could I test out?