### PR TITLE
fix(accessibility): stop scanning on EOF from stdin

### DIFF
--- a/accessibility/accessibility.go
+++ b/accessibility/accessibility.go
@@ -78,7 +78,12 @@ func PromptString(prompt string, validator func(input string) error) string {
 
 	for !valid {
 		fmt.Print(prompt)
-		_ = scanner.Scan()
+		if !scanner.Scan() {
+			// no way to bubble up errors or signal cancellation
+			// but the program is probably not continuing if
+			// stdin sent EOF
+			break
+		}
 		input = scanner.Text()
 
 		err := validator(input)


### PR DESCRIPTION
If a user send EOF to stdin (Ctrl-C) in the terminal while in accessibility mode, the program gets stuck in a loop printing errors about invalid input:

> Example:
> ![CleanShot 2024-10-25 at 19 19 41](https://github.com/user-attachments/assets/abe2742c-cefd-4c6d-9eac-489420224bef)
> "oh nooo....." screams the terminal, as it decides into a demented spiral

This change isn't ideal (it'd be better to somehow bubble up an error that stops execution) but it's better than getting the process stuck in a loop. An alternative that doesn't change the signature would be to panic, or `os.Exit` or something else. Happy with whatever.