### PR TITLE
fix(accessibility): parseBool defaults to no

### DIFF
--- a/accessibility/accessibility.go
+++ b/accessibility/accessibility.go
@@ -42,7 +42,9 @@ func parseBool(s string) (bool, error) {
 		}
 	}
 
-	for _, n := range []string{"n", "no"} {
+	// As a special case, we default to "" to no since the usage of this
+	// function suggests N is the default.
+	for _, n := range []string{"", "n", "no"} {
 		if n == s {
 			return false, nil
 		}


### PR DESCRIPTION
Matching the prompt of "Choose [y/N]:" default is now equal to N.

Resolves https://github.com/charmbracelet/huh/issues/264