### PR TITLE
Allow prev and next actions even when no options and no filtering

### DIFF
--- a/field_select.go
+++ b/field_select.go
@@ -449,9 +449,10 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			s.updateValue()
 		case key.Matches(msg, s.keymap.Prev):
-			if s.selected >= len(s.filteredOptions) {
+			if s.filtering && s.selected >= len(s.filteredOptions) {
 				break
 			}
+			s.setFiltering(false)
 			s.updateValue()
 			s.err = s.validate(s.accessor.Get())
 			if s.err != nil {
@@ -460,7 +461,7 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			s.updateValue()
 			return s, PrevField
 		case key.Matches(msg, s.keymap.Next, s.keymap.Submit):
-			if s.selected >= len(s.filteredOptions) {
+			if s.filtering && s.selected >= len(s.filteredOptions) {
 				break
 			}
 			s.setFiltering(false)


### PR DESCRIPTION
fixes #422

It disables prev and next actions when no options are available, including during filtering.