### PR TITLE
fix(filepicker): auto-height

### DIFF
--- a/examples/filepicker-picking/main.go
+++ b/examples/filepicker-picking/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+)
+
+func main() {
+	var file string
+	huh.NewForm(
+		huh.NewGroup(
+			huh.NewFilePicker().
+				Picking(true).
+				Title("Code").
+				Description("Select a .go file").
+				AllowedTypes([]string{".go"}).
+				Value(&file),
+		),
+	).WithShowHelp(true).Run()
+	fmt.Println(file)
+}

--- a/field_filepicker.go
+++ b/field_filepicker.go
@@ -45,7 +45,6 @@ type FilePicker struct {
 func NewFilePicker() *FilePicker {
 	fp := filepicker.New()
 	fp.ShowSize = false
-	fp.AutoHeight = false
 
 	if cmd := fp.Init(); cmd != nil {
 		fp, _ = fp.Update(cmd())
@@ -151,7 +150,6 @@ func (f *FilePicker) Height(height int) *FilePicker {
 		adjust++
 	}
 	f.picker.Height = height - adjust
-	f.picker.AutoHeight = false
 	return f
 }
 


### PR DESCRIPTION
Not sure why it was setting auto height to false, but this was causing some issues, especially when using `Picking(true)`, like gum does.

I didn't see any bad effects in removing it.
