### PR TITLE
fix: wrapped content in multi-select

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -555,15 +555,17 @@ func (m *MultiSelect[T]) optionsView() string {
 		} else {
 			sb.WriteString(strings.Repeat(" ", lipgloss.Width(c)))
 		}
-		prefixWidth := lipgloss.Width(styles.SelectedPrefix.String())
+		prefixWidth := max(lipgloss.Width(styles.SelectedPrefix.String()), lipgloss.Width(styles.UnselectedPrefix.String()))
 		contentWidth := m.width - prefixWidth - lipgloss.Width(c)
 
 		if m.filteredOptions[i].selected {
 			// add a prefix after each newline except the last one.
+			sb.WriteString(styles.SelectedPrefix.String())
 			content := styles.SelectedOption.Width(contentWidth).Render(option.Key)
 			strings.Replace(content, "\n", "\n"+styles.SelectedPrefix.String(), strings.Count(content, "\n")-1)
 			sb.WriteString(content)
 		} else {
+			sb.WriteString(styles.UnselectedPrefix.String())
 			content := styles.UnselectedOption.Width(contentWidth).Render(option.Key)
 			strings.Replace(content, "\n", "\n"+styles.UnselectedPrefix.String(), strings.Count(content, "\n")-1)
 			sb.WriteString(content)

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -555,20 +555,17 @@ func (m *MultiSelect[T]) optionsView() string {
 		} else {
 			sb.WriteString(strings.Repeat(" ", lipgloss.Width(c)))
 		}
+		// Calculate width constraints.
 		prefixWidth := max(lipgloss.Width(styles.SelectedPrefix.String()), lipgloss.Width(styles.UnselectedPrefix.String()))
-		contentWidth := m.width - prefixWidth - lipgloss.Width(c)
+		frameSize := styles.Base.GetHorizontalFrameSize()
+		contentWidth := m.width - frameSize - lipgloss.Width(c) - prefixWidth
 
 		if m.filteredOptions[i].selected {
-			// add a prefix after each newline except the last one.
 			sb.WriteString(styles.SelectedPrefix.String())
-			content := styles.SelectedOption.Width(contentWidth).Render(option.Key)
-			strings.Replace(content, "\n", "\n"+styles.SelectedPrefix.String(), strings.Count(content, "\n")-1)
-			sb.WriteString(content)
+			sb.WriteString(styles.SelectedOption.Width(contentWidth).Render(option.Key))
 		} else {
 			sb.WriteString(styles.UnselectedPrefix.String())
-			content := styles.UnselectedOption.Width(contentWidth).Render(option.Key)
-			strings.Replace(content, "\n", "\n"+styles.UnselectedPrefix.String(), strings.Count(content, "\n")-1)
-			sb.WriteString(content)
+			sb.WriteString(styles.UnselectedOption.Width(contentWidth).Render(option.Key))
 		}
 		if i < len(m.options.val)-1 {
 			sb.WriteString("\n")

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -267,6 +267,10 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		rendered := m.View()
+		m.WithHeight(max(m.height, min(lipgloss.Height(rendered), msg.Height-1)))
+		m.WithWidth(max(m.width, min(lipgloss.Width(rendered), msg.Width-1)))
 	case updateFieldMsg:
 		var fieldCmds []tea.Cmd
 		if ok, hash := m.title.shouldUpdate(); ok {
@@ -456,7 +460,7 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *MultiSelect[T]) updateViewportHeight() {
 	// If no height is set size the viewport to the number of options.
 	if m.height <= 0 {
-		m.viewport.Height = len(m.options.val)
+		m.viewport.Height = lipgloss.Height(m.optionsView())
 		return
 	}
 

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -267,8 +267,6 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
-	case tea.WindowSizeMsg:
-		m.updateViewportHeight()
 	case updateFieldMsg:
 		var fieldCmds []tea.Cmd
 		if ok, hash := m.title.shouldUpdate(); ok {

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -559,13 +559,18 @@ func (m *MultiSelect[T]) optionsView() string {
 		} else {
 			sb.WriteString(strings.Repeat(" ", lipgloss.Width(c)))
 		}
+		prefixWidth := lipgloss.Width(styles.SelectedPrefix.String())
+		contentWidth := m.width - prefixWidth
 
 		if m.filteredOptions[i].selected {
-			sb.WriteString(styles.SelectedPrefix.String())
-			sb.WriteString(styles.SelectedOption.Render(option.Key))
+			// add a prefix after each newline except the last one.
+			content := styles.SelectedOption.Width(contentWidth).Render(option.Key)
+			strings.Replace(content, "\n", "\n"+styles.SelectedPrefix.String(), strings.Count(content, "\n")-1)
+			sb.WriteString(content)
 		} else {
-			sb.WriteString(styles.UnselectedPrefix.String())
-			sb.WriteString(styles.UnselectedOption.Render(option.Key))
+			content := styles.UnselectedOption.Width(contentWidth).Render(option.Key)
+			strings.Replace(content, "\n", "\n"+styles.UnselectedPrefix.String(), strings.Count(content, "\n")-1)
+			sb.WriteString(content)
 		}
 		if i < len(m.options.val)-1 {
 			sb.WriteString("\n")

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -268,9 +268,7 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		rendered := m.View()
-		m.WithHeight(max(m.height, min(lipgloss.Height(rendered), msg.Height-1)))
-		m.WithWidth(max(m.width, min(lipgloss.Width(rendered), msg.Width-1)))
+		m.updateViewportHeight()
 	case updateFieldMsg:
 		var fieldCmds []tea.Cmd
 		if ok, hash := m.title.shouldUpdate(); ok {
@@ -560,7 +558,7 @@ func (m *MultiSelect[T]) optionsView() string {
 			sb.WriteString(strings.Repeat(" ", lipgloss.Width(c)))
 		}
 		prefixWidth := lipgloss.Width(styles.SelectedPrefix.String())
-		contentWidth := m.width - prefixWidth
+		contentWidth := m.width - prefixWidth - lipgloss.Width(c)
 
 		if m.filteredOptions[i].selected {
 			// add a prefix after each newline except the last one.

--- a/group.go
+++ b/group.go
@@ -269,6 +269,7 @@ func (g *Group) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		g.WithHeight(max(g.height, min(g.fullHeight(), msg.Height-1)))
+		g.WithWidth(max(g.width, min(g.fullWidth(), msg.Width-1)))
 	case nextFieldMsg:
 		cmds = append(cmds, g.nextField()...)
 	case prevFieldMsg:
@@ -288,6 +289,16 @@ func (g *Group) fullHeight() int {
 		return true
 	})
 	return height
+}
+
+// width returns the full width of the group.
+func (g *Group) fullWidth() int {
+	width := g.selector.Total()
+	g.selector.Range(func(_ int, field Field) bool {
+		width += lipgloss.Width(field.View())
+		return true
+	})
+	return width
 }
 
 func (g *Group) getContent() (int, string) {


### PR DESCRIPTION
- **feat: set group with from size msg**
- **feat: handle WindowSizeMsg + base height on rendered content**
- **feat: render prefix before newlines**
- **feat: update viewport on resize, cursor != height so no scroll...**
- **fix: always update viewport height**
