### PR TITLE
Applies description style to note description

### DIFF
--- a/field_note.go
+++ b/field_note.go
@@ -224,7 +224,7 @@ func (n *Note) View() string {
 	}
 	if n.description.val != "" || n.description.fn != nil {
 		sb.WriteString("\n")
-		sb.WriteString(render(n.description.val))
+		sb.WriteString(styles.Description.Render(n.description.val))
 	}
 	if n.showNextButton {
 		sb.WriteString(styles.Next.Render(n.nextLabel))


### PR DESCRIPTION
I wasn't sure how to run local tests, but this seems like it should work...? (Sorry.) 

Currently, description theming doesn't apply to note fields; this is meant to correct that.