### PR TITLE
feat: option to disable external editor in Text field

### DIFF
--- a/field_text.go
+++ b/field_text.go
@@ -27,6 +27,7 @@ type Text struct {
 	description Eval[string]
 	placeholder Eval[string]
 
+	externalEditor  bool
 	editorCmd       string
 	editorArgs      []string
 	editorExtension string
@@ -62,6 +63,7 @@ func NewText() *Text {
 		id:              nextID(),
 		textarea:        text,
 		validate:        func(string) error { return nil },
+		externalEditor:  true,
 		editorCmd:       editorCmd,
 		editorArgs:      editorArgs,
 		editorExtension: "md",
@@ -180,6 +182,12 @@ func (t *Text) Validate(validate func(string) error) *Text {
 	return t
 }
 
+// ExternalEditor sets whether option to launch an editor is available.
+func (t *Text) ExternalEditor(editor bool) *Text {
+	t.externalEditor = editor
+	return t
+}
+
 const defaultEditor = "nano"
 
 // getEditor returns the editor command and arguments.
@@ -237,6 +245,7 @@ func (t *Text) Blur() tea.Cmd {
 
 // KeyBinds returns the help message for the text field.
 func (t *Text) KeyBinds() []key.Binding {
+	t.keymap.Editor.SetEnabled(t.externalEditor)
 	return []key.Binding{t.keymap.NewLine, t.keymap.Editor, t.keymap.Prev, t.keymap.Submit, t.keymap.Next}
 }
 

--- a/huh_test.go
+++ b/huh_test.go
@@ -374,6 +374,31 @@ func TestText(t *testing.T) {
 	}
 }
 
+func TestTextExternalEditorHidden(t *testing.T) {
+	field := NewText().ExternalEditor(false)
+	f := NewForm(NewGroup(field))
+	f.Update(f.Init())
+
+	// Type Huh in the form.
+	m, _ := f.Update(keys('H', 'u', 'h'))
+	f = m.(*Form)
+	view := ansi.Strip(f.View())
+
+	if !strings.Contains(view, "Huh") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected field to contain Huh.")
+	}
+
+	if strings.Contains(view, "ctrl+e open editor") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected field to contain help without ctrl+e.")
+	}
+
+	if field.GetValue() != "Huh" {
+		t.Error("Expected field value to be Huh")
+	}
+}
+
 func TestConfirm(t *testing.T) {
 	field := NewConfirm().Title("Are you sure?")
 	f := NewForm(NewGroup(field))


### PR DESCRIPTION
Adds the ability to disable the external editor option in text fields. I was looking for this feature when I noticed that someone else had asked for the same thing in issue #512 