### PR TITLE
feat: method to check filtering state of select fields

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -761,3 +761,8 @@ func (m *MultiSelect[T]) GetKey() string {
 func (m *MultiSelect[T]) GetValue() any {
 	return m.accessor.Get()
 }
+
+// GetFiltering returns whether the multi-select is filtering.
+func (m *MultiSelect[T]) GetFiltering() bool {
+	return m.filtering
+}

--- a/field_select.go
+++ b/field_select.go
@@ -730,3 +730,8 @@ func (s *Select[T]) GetKey() string { return s.key }
 func (s *Select[T]) GetValue() any {
 	return s.accessor.Get()
 }
+
+// GetFiltering returns the filtering state of the field.
+func (s *Select[T]) GetFiltering() bool {
+	return s.filtering
+}


### PR DESCRIPTION
Hi,

Currently, it isn't possible to get the filtering state of a `huh.Field`. 
I found a use case, where this can be useful. I'm using `huh` as a bubbletea bubble to highjack some key binding, but only if the form isn't filtered. 