### PR TITLE
feat: group titles and descriptions

### DIFF
--- a/examples/issue-522/main.go
+++ b/examples/issue-522/main.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/charmbracelet/huh"
+
+func main() {
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().Title("First"),
+			huh.NewInput().Title("Second"),
+			huh.NewInput().Title("Third").Description("maoe"),
+		).Title("Group Title").Description("Group Description"),
+	)
+	form.Run()
+}

--- a/field_confirm.go
+++ b/field_confirm.go
@@ -234,20 +234,27 @@ func (c *Confirm) activeStyles() *FieldStyles {
 func (c *Confirm) View() string {
 	styles := c.activeStyles()
 
+	var wroteHeader bool
 	var sb strings.Builder
-	sb.WriteString(styles.Title.Render(c.title.val))
+	if c.title.val != "" {
+		sb.WriteString(styles.Title.Render(c.title.val))
+		wroteHeader = true
+	}
 	if c.err != nil {
 		sb.WriteString(styles.ErrorIndicator.String())
+		wroteHeader = true
 	}
 
-	description := styles.Description.Render(c.description.val)
-
-	if !c.inline && (c.description.val != "" || c.description.fn != nil) {
-		sb.WriteString("\n")
+	if c.description.val != "" {
+		description := styles.Description.Render(c.description.val)
+		if !c.inline && (c.description.val != "" || c.description.fn != nil) {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(description)
+		wroteHeader = true
 	}
-	sb.WriteString(description)
 
-	if !c.inline {
+	if !c.inline && wroteHeader {
 		sb.WriteString("\n")
 		sb.WriteString("\n")
 	}
@@ -297,8 +304,10 @@ func (c *Confirm) Run() error {
 // runAccessible runs the confirm field in accessible mode.
 func (c *Confirm) runAccessible() error {
 	styles := c.activeStyles()
-	fmt.Println(styles.Title.Render(c.title.val))
-	fmt.Println()
+	if c.title.val != "" {
+		fmt.Println(styles.Title.Render(c.title.val))
+		fmt.Println()
+	}
 	c.accessor.Set(accessibility.PromptBool())
 	fmt.Println(styles.SelectedOption.Render("Chose: "+c.String()) + "\n")
 	return nil

--- a/huh_test.go
+++ b/huh_test.go
@@ -920,32 +920,24 @@ func TestAbort(t *testing.T) {
 	}
 }
 
-func TestGroupTitleAndDescription(t *testing.T) {
-	f := NewForm(
-		NewGroup(
-			NewConfirm().Title("Confirm?"),
-		).
-			Title("Group title").
-			Description("Group description"),
-	)
-	f.Update(f.Init())
+func TestTitleRowRender(t *testing.T) {
+	t.Run("Group", func(t *testing.T) {
+		c := NewGroup(NewConfirm()).Title("A Title")
+		if view := c.View(); !strings.Contains(view, "A Title") {
+			t.Log(pretty.Render(view))
+			t.Error("Expected title to be visible")
+		}
+	})
+}
 
-	view := ansi.Strip(f.View())
-
-	if !strings.Contains(view, "title") {
-		t.Log(view)
-		t.Error("Expected field to contain group title.")
-	}
-
-	if !strings.Contains(view, "Confirm") {
-		t.Log(view)
-		t.Error("Expected field to contain confirmation")
-	}
-
-	if !strings.Contains(view, "enter submit") {
-		t.Log(view)
-		t.Error("Expected field to contain help.")
-	}
+func TestDescriptionRowRender(t *testing.T) {
+	t.Run("Group", func(t *testing.T) {
+		c := NewGroup(NewConfirm()).Description("A Description")
+		if view := c.View(); !strings.Contains(view, "A Description") {
+			t.Log(pretty.Render(view))
+			t.Error("Expected description to be visible")
+		}
+	})
 }
 
 // formProgram returns a new Form with a nil input and output, so it can be used as a test program.

--- a/huh_test.go
+++ b/huh_test.go
@@ -926,47 +926,80 @@ const (
 )
 
 var titleAndDescTests = map[string]struct {
+	Empty       interface{ View() string }
+	EmptyHeight int
 	Title       interface{ View() string }
 	Description interface{ View() string }
 }{
 	"Group": {
-		NewGroup(NewConfirm()).Title(title),
-		NewGroup(NewConfirm()).Description(description),
+		NewGroup(NewInput()),
+		3, // \n> \n
+		NewGroup(NewInput()).Title(title),
+		NewGroup(NewInput()).Description(description),
 	},
 	"Confirm": {
+		NewConfirm(),
+		1, // yes | no
 		NewConfirm().Title(title),
 		NewConfirm().Description(description),
 	},
 	"FilePicker": {
+		NewFilePicker(),
+		1, // "no file selected"
 		NewFilePicker().Title(title),
 		NewFilePicker().Description(description),
 	},
 	"Input": {
+		NewInput(),
+		1, // >
 		NewInput().Title(title),
 		NewInput().Description(description),
 	},
 	"Note": {
+		NewNote(),
+		1, // |
 		NewNote().Title(title),
 		NewNote().Description(description),
 	},
 	"Text": {
+		NewText(),
+		6, // textarea
 		NewText().Title(title),
 		NewText().Description(description),
 	},
 	"Select": {
+		NewSelect[string](),
+		1, // >
 		NewSelect[string]().Title(title),
 		NewSelect[string]().Description(description),
 	},
 	"MultiSelect": {
+		NewMultiSelect[string](),
+		1, // >
 		NewMultiSelect[string]().Title(title),
 		NewMultiSelect[string]().Description(description),
 	},
 }
 
+func TestNoTitleOrDescription(t *testing.T) {
+	for name, tt := range titleAndDescTests {
+		t.Run(name, func(t *testing.T) {
+			view := tt.Empty.View()
+			got := lipgloss.Height(ansi.Strip(view))
+			want := tt.EmptyHeight
+			if got != want {
+				t.Log(pretty.Render(view))
+				t.Fatalf("got != want; height should be %d, got %d", want, got)
+			}
+		})
+	}
+}
+
 func TestTitleRowRender(t *testing.T) {
 	for name, tt := range titleAndDescTests {
 		t.Run(name, func(t *testing.T) {
-			if view := tt.Title.View(); !strings.Contains(view, title) {
+			view := tt.Title.View()
+			if !strings.Contains(view, title) {
 				t.Log(pretty.Render(view))
 				t.Error("Expected title to be visible")
 			}
@@ -977,7 +1010,8 @@ func TestTitleRowRender(t *testing.T) {
 func TestDescriptionRowRender(t *testing.T) {
 	for name, tt := range titleAndDescTests {
 		t.Run(name, func(t *testing.T) {
-			if view := tt.Description.View(); !strings.Contains(view, description) {
+			view := tt.Description.View()
+			if !strings.Contains(view, description) {
 				t.Log(pretty.Render(view))
 				t.Error("Expected description to be visible")
 			}

--- a/huh_test.go
+++ b/huh_test.go
@@ -920,6 +920,34 @@ func TestAbort(t *testing.T) {
 	}
 }
 
+func TestGroupTitleAndDescription(t *testing.T) {
+	f := NewForm(
+		NewGroup(
+			NewConfirm().Title("Confirm?"),
+		).
+			Title("Group title").
+			Description("Group description"),
+	)
+	f.Update(f.Init())
+
+	view := ansi.Strip(f.View())
+
+	if !strings.Contains(view, "title") {
+		t.Log(view)
+		t.Error("Expected field to contain group title.")
+	}
+
+	if !strings.Contains(view, "Confirm") {
+		t.Log(view)
+		t.Error("Expected field to contain confirmation")
+	}
+
+	if !strings.Contains(view, "enter submit") {
+		t.Log(view)
+		t.Error("Expected field to contain help.")
+	}
+}
+
 // formProgram returns a new Form with a nil input and output, so it can be used as a test program.
 func formProgram() *Form {
 	return NewForm(NewGroup(NewInput().Title("Foo"))).

--- a/huh_test.go
+++ b/huh_test.go
@@ -920,24 +920,69 @@ func TestAbort(t *testing.T) {
 	}
 }
 
+const (
+	title       = "A Title"
+	description = "A Description"
+)
+
+var titleAndDescTests = map[string]struct {
+	Title       interface{ View() string }
+	Description interface{ View() string }
+}{
+	"Group": {
+		NewGroup(NewConfirm()).Title(title),
+		NewGroup(NewConfirm()).Description(description),
+	},
+	"Confirm": {
+		NewConfirm().Title(title),
+		NewConfirm().Description(description),
+	},
+	"FilePicker": {
+		NewFilePicker().Title(title),
+		NewFilePicker().Description(description),
+	},
+	"Input": {
+		NewInput().Title(title),
+		NewInput().Description(description),
+	},
+	"Note": {
+		NewNote().Title(title),
+		NewNote().Description(description),
+	},
+	"Text": {
+		NewText().Title(title),
+		NewText().Description(description),
+	},
+	"Select": {
+		NewSelect[string]().Title(title),
+		NewSelect[string]().Description(description),
+	},
+	"MultiSelect": {
+		NewMultiSelect[string]().Title(title),
+		NewMultiSelect[string]().Description(description),
+	},
+}
+
 func TestTitleRowRender(t *testing.T) {
-	t.Run("Group", func(t *testing.T) {
-		c := NewGroup(NewConfirm()).Title("A Title")
-		if view := c.View(); !strings.Contains(view, "A Title") {
-			t.Log(pretty.Render(view))
-			t.Error("Expected title to be visible")
-		}
-	})
+	for name, tt := range titleAndDescTests {
+		t.Run(name, func(t *testing.T) {
+			if view := tt.Title.View(); !strings.Contains(view, title) {
+				t.Log(pretty.Render(view))
+				t.Error("Expected title to be visible")
+			}
+		})
+	}
 }
 
 func TestDescriptionRowRender(t *testing.T) {
-	t.Run("Group", func(t *testing.T) {
-		c := NewGroup(NewConfirm()).Description("A Description")
-		if view := c.View(); !strings.Contains(view, "A Description") {
-			t.Log(pretty.Render(view))
-			t.Error("Expected description to be visible")
-		}
-	})
+	for name, tt := range titleAndDescTests {
+		t.Run(name, func(t *testing.T) {
+			if view := tt.Description.View(); !strings.Contains(view, description) {
+				t.Log(pretty.Render(view))
+				t.Error("Expected description to be visible")
+			}
+		})
+	}
 }
 
 // formProgram returns a new Form with a nil input and output, so it can be used as a test program.

--- a/huh_test.go
+++ b/huh_test.go
@@ -614,62 +614,64 @@ func TestSelectPageNavigation(t *testing.T) {
 	reLast := regexp.MustCompile(`>( •)? Ping`)
 	reHalfDown := regexp.MustCompile(`>( •)? Baz`)
 
-	for _, field := range []Field{
-		NewMultiSelect[string]().Options(opts...).Title("Choose"),
-		NewSelect[string]().Options(opts...).Title("Choose"),
+	for name, field := range map[string]Field{
+		"multiselect": NewMultiSelect[string]().Options(opts...).Title("Choose"),
+		"select":      NewSelect[string]().Options(opts...).Title("Choose"),
 	} {
-		f := NewForm(NewGroup(field)).WithHeight(10)
-		f.Update(f.Init())
+		t.Run(name, func(t *testing.T) {
+			f := NewForm(NewGroup(field)).WithHeight(10)
+			f.Update(f.Init())
 
-		view := ansi.Strip(f.View())
-		if !reFirst.MatchString(view) {
-			t.Log(pretty.Render(view))
-			t.Error("Wrong item selected")
-		}
+			view := ansi.Strip(f.View())
+			if !reFirst.MatchString(view) {
+				t.Log(pretty.Render(view))
+				t.Errorf("Wrong item selected, should have matched %q (first item)", reFirst.String())
+			}
 
-		m, _ := f.Update(keys('G'))
-		view = ansi.Strip(m.View())
-		if !reLast.MatchString(view) {
-			t.Log(pretty.Render(view))
-			t.Error("Wrong item selected")
-		}
+			m, _ := f.Update(keys('G'))
+			view = ansi.Strip(m.View())
+			if !reLast.MatchString(view) {
+				t.Log(pretty.Render(view))
+				t.Errorf("Wrong item selected, should have matched %q (last item)", reLast.String())
+			}
 
-		m, _ = f.Update(keys('g'))
-		view = ansi.Strip(m.View())
-		if !reFirst.MatchString(view) {
-			t.Log(pretty.Render(view))
-			t.Error("Wrong item selected")
-		}
+			m, _ = f.Update(keys('g'))
+			view = ansi.Strip(m.View())
+			if !reFirst.MatchString(view) {
+				t.Log(pretty.Render(view))
+				t.Errorf("Wrong item selected, should have matched %q (first item)", reFirst.String())
+			}
 
-		m, _ = f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
-		view = ansi.Strip(m.View())
-		if !reHalfDown.MatchString(view) {
-			t.Log(pretty.Render(view))
-			t.Error("Wrong item selected")
-		}
+			m, _ = f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+			view = ansi.Strip(m.View())
+			if !reHalfDown.MatchString(view) {
+				t.Log(pretty.Render(view))
+				t.Errorf("Wrong item selected, should have matched %q (half down item)", reHalfDown.String())
+			}
 
-		// sends multiple to verify it stays within boundaries
-		f.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
-		f.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
-		m, _ = f.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
-		view = ansi.Strip(m.View())
-		if !reFirst.MatchString(view) {
-			t.Log(pretty.Render(view))
-			t.Error("Wrong item selected")
-		}
+			// sends multiple to verify it stays within boundaries
+			f.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+			f.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+			m, _ = f.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+			view = ansi.Strip(m.View())
+			if !reFirst.MatchString(view) {
+				t.Log(pretty.Render(view))
+				t.Errorf("Wrong item selected, should have matched %q (first item)", reFirst.String())
+			}
 
-		// verify it stays within boundaries
-		f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
-		f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
-		f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
-		f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
-		f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
-		m, _ = f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
-		view = ansi.Strip(m.View())
-		if !reLast.MatchString(view) {
-			t.Log(pretty.Render(view))
-			t.Error("Wrong item selected")
-		}
+			// verify it stays within boundaries
+			f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+			f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+			f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+			f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+			f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+			m, _ = f.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+			view = ansi.Strip(m.View())
+			if !reLast.MatchString(view) {
+				t.Log(pretty.Render(view))
+				t.Errorf("Wrong item selected, should have matched %q (last item)", reLast.String())
+			}
+		})
 	}
 }
 

--- a/layout.go
+++ b/layout.go
@@ -74,9 +74,12 @@ func (l *layoutColumns) View(f *Form) string {
 	for _, group := range groups {
 		columns = append(columns, group.Content())
 	}
+
+	header := f.selector.Selected().Header()
 	footer := f.selector.Selected().Footer()
 
 	return lipgloss.JoinVertical(lipgloss.Left,
+		header,
 		lipgloss.JoinHorizontal(lipgloss.Top, columns...),
 		footer,
 	)

--- a/theme.go
+++ b/theme.go
@@ -10,11 +10,17 @@ import (
 // Themes can be applied to a form using the WithTheme option.
 type Theme struct {
 	Form           lipgloss.Style
-	Group          lipgloss.Style
+	Group          GroupStyles
 	FieldSeparator lipgloss.Style
 	Blurred        FieldStyles
 	Focused        FieldStyles
 	Help           help.Styles
+}
+
+type GroupStyles struct {
+	Base        lipgloss.Style
+	Title       lipgloss.Style
+	Description lipgloss.Style
 }
 
 // FieldStyles are the styles for input fields.
@@ -149,6 +155,8 @@ func ThemeCharm() *Theme {
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
 
+	t.Group.Title = t.Focused.Title.Foreground(indigo).Bold(true)
+	t.Group.Description = t.Focused.Description.Foreground(lipgloss.AdaptiveColor{Light: "", Dark: "243"})
 	return t
 }
 
@@ -196,6 +204,8 @@ func ThemeDracula() *Theme {
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
 
+	t.Group.Title = t.Focused.Title.Foreground(purple)
+	t.Group.Description = t.Focused.Description.Foreground(comment)
 	return t
 }
 
@@ -235,6 +245,9 @@ func ThemeBase16() *Theme {
 
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
+
+	t.Group.Title = t.Focused.Title.Foreground(lipgloss.Color("6"))
+	t.Group.Description = t.Focused.Description.Foreground(lipgloss.Color("8"))
 
 	return t
 }
@@ -293,5 +306,7 @@ func ThemeCatppuccin() *Theme {
 	t.Help.FullDesc = t.Help.FullDesc.Foreground(overlay1)
 	t.Help.FullSeparator = t.Help.FullSeparator.Foreground(subtext0)
 
+	t.Group.Title = t.Focused.Title.Foreground(mauve)
+	t.Group.Description = t.Focused.Description.Foreground(subtext0)
 	return t
 }

--- a/theme.go
+++ b/theme.go
@@ -17,8 +17,8 @@ type Theme struct {
 	Help           help.Styles
 }
 
+// GroupStyles are the styles for a group.
 type GroupStyles struct {
-	Base        lipgloss.Style
 	Title       lipgloss.Style
 	Description lipgloss.Style
 }
@@ -155,8 +155,8 @@ func ThemeCharm() *Theme {
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
 
-	t.Group.Title = t.Focused.Title.Foreground(indigo).Bold(true)
-	t.Group.Description = t.Focused.Description.Foreground(lipgloss.AdaptiveColor{Light: "", Dark: "243"})
+	t.Group.Title = t.Focused.Title
+	t.Group.Description = t.Focused.Description
 	return t
 }
 
@@ -204,8 +204,8 @@ func ThemeDracula() *Theme {
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
 
-	t.Group.Title = t.Focused.Title.Foreground(purple)
-	t.Group.Description = t.Focused.Description.Foreground(comment)
+	t.Group.Title = t.Focused.Title
+	t.Group.Description = t.Focused.Description
 	return t
 }
 
@@ -246,8 +246,8 @@ func ThemeBase16() *Theme {
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
 
-	t.Group.Title = t.Focused.Title.Foreground(lipgloss.Color("6"))
-	t.Group.Description = t.Focused.Description.Foreground(lipgloss.Color("8"))
+	t.Group.Title = t.Focused.Title
+	t.Group.Description = t.Focused.Description
 
 	return t
 }
@@ -306,7 +306,7 @@ func ThemeCatppuccin() *Theme {
 	t.Help.FullDesc = t.Help.FullDesc.Foreground(overlay1)
 	t.Help.FullSeparator = t.Help.FullSeparator.Foreground(subtext0)
 
-	t.Group.Title = t.Focused.Title.Foreground(mauve)
-	t.Group.Description = t.Focused.Description.Foreground(subtext0)
+	t.Group.Title = t.Focused.Title
+	t.Group.Description = t.Focused.Description
 	return t
 }


### PR DESCRIPTION
- adds group styles (the bare `group lipgloss.Style` was never used)
- group keeps track of the theme now
- the groups were not using title or description anywhere
- added both title and description to the view
- fixes viewport calculations
- fixes confirm extra empty lines when no title/description

![CleanShot 2025-03-07 at 12 10 53@2x](https://github.com/user-attachments/assets/6fd208aa-3ef8-4823-8a62-6b3feec7cf7f)

closes #522
closes #385
closes #560 
