### PR TITLE
fix(select,multiselect): multi line items, scrolling

### DIFF
--- a/field_select.go
+++ b/field_select.go
@@ -514,7 +514,8 @@ func (s *Select[T]) updateValue() {
 func (s *Select[T]) updateViewportHeight() {
 	// If no height is set size the viewport to the number of options.
 	if s.height <= 0 {
-		s.viewport.Height = len(s.options.val)
+		v, _, _ := s.optionsView()
+		s.viewport.Height = lipgloss.Height(v)
 		return
 	}
 

--- a/field_select.go
+++ b/field_select.go
@@ -580,16 +580,16 @@ func (s *Select[T]) optionsView() (string, int, int) {
 		return sb.String(), -1, 1
 	}
 
-	var selectOffset int
-	var selectedHeight int
+	var cursorOffset int
+	var cursorHeight int
 	for i, option := range s.filteredOptions {
 		selected := s.selected == i
 		line := s.renderOption(option, selected)
 		if i < s.selected {
-			selectOffset += lipgloss.Height(line)
+			cursorOffset += lipgloss.Height(line)
 		}
 		if selected {
-			selectedHeight = lipgloss.Height(line)
+			cursorHeight = lipgloss.Height(line)
 		}
 
 		sb.WriteString(line)
@@ -602,7 +602,7 @@ func (s *Select[T]) optionsView() (string, int, int) {
 		sb.WriteString("\n")
 	}
 
-	return sb.String(), selectOffset, selectedHeight
+	return sb.String(), cursorOffset, cursorHeight
 }
 
 func (s *Select[T]) renderOption(option Option[T], selected bool) string {

--- a/field_select.go
+++ b/field_select.go
@@ -320,11 +320,6 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	if s.filtering {
 		s.filter, cmd = s.filter.Update(msg)
-
-		// Keep the selected item in view.
-		if s.selected < s.viewport.YOffset || s.selected >= s.viewport.YOffset+s.viewport.Height {
-			s.viewport.SetYOffset(s.selected)
-		}
 	}
 
 	switch msg := msg.(type) {
@@ -496,8 +491,12 @@ func (s *Select[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if len(s.filteredOptions) > 0 {
 				s.selected = min(s.selected, len(s.filteredOptions)-1)
-				s.viewport.SetYOffset(clamp(s.selected, 0, len(s.filteredOptions)-s.viewport.Height))
 			}
+		}
+
+		_, offset, height := s.optionsView()
+		if offset > -1 && height > 0 && (offset < s.viewport.YOffset || height+offset >= s.viewport.YOffset+s.viewport.Height) {
+			s.viewport.SetYOffset(offset)
 		}
 	}
 
@@ -557,17 +556,16 @@ func (s *Select[T]) descriptionView() string {
 	return s.activeStyles().Description.Render(s.description.val)
 }
 
-func (s *Select[T]) optionsView() string {
+func (s *Select[T]) optionsView() (string, int, int) {
 	var (
 		styles = s.activeStyles()
-		c      = styles.SelectSelector.String()
 		sb     strings.Builder
 	)
 
 	if s.options.loading && time.Since(s.options.loadingStart) > spinnerShowThreshold {
 		s.spinner.Style = s.activeStyles().MultiSelectSelector.UnsetString()
 		sb.WriteString(s.spinner.View() + " Loading...")
-		return sb.String()
+		return sb.String(), -1, 1
 	}
 
 	if s.inline {
@@ -578,15 +576,22 @@ func (s *Select[T]) optionsView() string {
 			sb.WriteString(styles.TextInput.Placeholder.Render("No matches"))
 		}
 		sb.WriteString(styles.NextIndicator.Faint(s.selected == len(s.filteredOptions)-1).String())
-		return sb.String()
+		return sb.String(), -1, 1
 	}
 
+	var selectOffset int
+	var selectedHeight int
 	for i, option := range s.filteredOptions {
-		if s.selected == i {
-			sb.WriteString(c + styles.SelectedOption.Render(option.Key))
-		} else {
-			sb.WriteString(strings.Repeat(" ", lipgloss.Width(c)) + styles.UnselectedOption.Render(option.Key))
+		selected := s.selected == i
+		line := s.renderOption(option, selected)
+		if i < s.selected {
+			selectOffset += lipgloss.Height(line)
 		}
+		if selected {
+			selectedHeight = lipgloss.Height(line)
+		}
+
+		sb.WriteString(line)
 		if i < len(s.options.val)-1 {
 			sb.WriteString("\n")
 		}
@@ -596,13 +601,34 @@ func (s *Select[T]) optionsView() string {
 		sb.WriteString("\n")
 	}
 
-	return sb.String()
+	return sb.String(), selectOffset, selectedHeight
+}
+
+func (s *Select[T]) renderOption(option Option[T], selected bool) string {
+	var (
+		styles = s.activeStyles()
+		cursor = styles.SelectSelector.String()
+	)
+
+	if selected {
+		return lipgloss.JoinHorizontal(
+			lipgloss.Top,
+			cursor,
+			styles.SelectedOption.Render(option.Key),
+		)
+	}
+	return lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		strings.Repeat(" ", lipgloss.Width(cursor)),
+		styles.UnselectedOption.Render(option.Key),
+	)
 }
 
 // View renders the select field.
 func (s *Select[T]) View() string {
 	styles := s.activeStyles()
-	s.viewport.SetContent(s.optionsView())
+	vpc, _, _ := s.optionsView()
+	s.viewport.SetContent(vpc)
 
 	var sb strings.Builder
 	if s.title.val != "" || s.title.fn != nil {

--- a/huh_test.go
+++ b/huh_test.go
@@ -434,14 +434,14 @@ func TestConfirm(t *testing.T) {
 	}
 
 	// Toggle left
-	m, _ = f.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	f.Update(tea.KeyMsg{Type: tea.KeyLeft})
 
 	if field.GetValue() != true {
 		t.Error("Expected field value to be true")
 	}
 
 	// Toggle right
-	m, _ = f.Update(tea.KeyMsg{Type: tea.KeyRight})
+	f.Update(tea.KeyMsg{Type: tea.KeyRight})
 
 	if field.GetValue() != false {
 		t.Error("Expected field value to be false")
@@ -449,8 +449,15 @@ func TestConfirm(t *testing.T) {
 }
 
 func TestSelect(t *testing.T) {
-	field := NewSelect[string]().Options(NewOptions("Foo", "Bar", "Baz")...).Title("Which one?")
-	f := NewForm(NewGroup(field))
+	field := NewSelect[string]().
+		Options(NewOptions(
+			"Foo\nLine 2",
+			"Bar\nLine 2",
+			"Baz\nLine 2",
+			"Ban\nLine 2",
+		)...).
+		Title("Which one?")
+	f := NewForm(NewGroup(field)).WithHeight(5)
 	f.Update(f.Init())
 
 	view := ansi.Strip(f.View())
@@ -476,7 +483,7 @@ func TestSelect(t *testing.T) {
 
 	view = ansi.Strip(f.View())
 
-	if got, ok := field.Hovered(); !ok || got != "Bar" {
+	if got, ok := field.Hovered(); !ok || got != "Bar\nLine 2" {
 		t.Log(pretty.Render(view))
 		t.Error("Expected cursor to be on Bar.")
 	}
@@ -497,17 +504,24 @@ func TestSelect(t *testing.T) {
 	}
 
 	// Submit
-	m, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	f = m.(*Form)
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter})
 
-	if field.GetValue() != "Bar" {
+	if field.GetValue() != "Bar\nLine 2" {
 		t.Error("Expected field value to be Bar")
 	}
 }
 
 func TestMultiSelect(t *testing.T) {
-	field := NewMultiSelect[string]().Options(NewOptions("Foo", "Bar", "Baz")...).Title("Which one?")
-	f := NewForm(NewGroup(field))
+	field := NewMultiSelect[string]().
+		Options(NewOptions(
+			"Foo\nLine2",
+			"Bar\nLine2",
+			"Baz\nLine2",
+			"Ban\nLine2",
+		)...).
+		Title("Which one?")
+	f := NewForm(NewGroup(field)).
+		WithHeight(5)
 	f.Update(f.Init())
 
 	view := ansi.Strip(f.View())
@@ -531,7 +545,7 @@ func TestMultiSelect(t *testing.T) {
 	m, _ := f.Update(keys('j'))
 	view = ansi.Strip(m.View())
 
-	if got, ok := field.Hovered(); !ok || got != "Bar" {
+	if got, ok := field.Hovered(); !ok || got != "Bar\nLine2" {
 		t.Log(pretty.Render(view))
 		t.Error("Expected cursor to be on Bar.")
 	}
@@ -561,8 +575,7 @@ func TestMultiSelect(t *testing.T) {
 	}
 
 	// Submit
-	m, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	f = m.(*Form)
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter})
 
 	value := field.GetValue()
 	if value, ok := value.([]string); !ok {
@@ -571,8 +584,8 @@ func TestMultiSelect(t *testing.T) {
 		if len(value) != 1 {
 			t.Error("Expected field value length to be 1")
 		} else {
-			if value[0] != "Bar" {
-				t.Error("Expected first field value length to be Bar")
+			if value[0] != "Bar\nLine2" {
+				t.Error("Expected first field value to be Bar")
 			}
 		}
 	}


### PR DESCRIPTION
- properly render multi line items by using `lipgloss.JoinHorizontal`
- properly handle scrolling when an item has multiple lines
- added tests


closes https://github.com/charmbracelet/huh/issues/429

---

## Before

![CleanShot 2025-03-11 at 14 36 06](https://github.com/user-attachments/assets/3ee2f5c2-84b4-4e5e-b08c-c0778e65ae76)

https://github.com/user-attachments/assets/c8a908a1-dfc8-4bf3-abe0-700bdb42e2d6

## After

![CleanShot 2025-03-11 at 14 34 11](https://github.com/user-attachments/assets/8fd247f4-0f9a-48a3-b272-1d03ae156718)

https://github.com/user-attachments/assets/9f951c78-daab-4445-b43d-4de56c93c904



