### PR TITLE
fix: height and width calculation improvements, wrapping

### DIFF
--- a/examples/bubbletea/main.go
+++ b/examples/bubbletea/main.go
@@ -206,7 +206,7 @@ func (m Model) View() string {
 		if len(errors) > 0 {
 			header = m.appErrorBoundaryView(m.errorView())
 		}
-		body := lipgloss.JoinHorizontal(lipgloss.Top, form, status)
+		body := lipgloss.JoinHorizontal(lipgloss.Left, form, status)
 
 		footer := m.appBoundaryView(m.form.Help().ShortHelpView(m.form.KeyBinds()))
 		if len(errors) > 0 {

--- a/examples/dynamic/dynamic-bubbletea/main.go
+++ b/examples/dynamic/dynamic-bubbletea/main.go
@@ -215,7 +215,7 @@ func (m Model) View() string {
 		if len(errors) > 0 {
 			header = m.appErrorBoundaryView(m.errorView())
 		}
-		body := lipgloss.JoinHorizontal(lipgloss.Top, form, status)
+		body := lipgloss.JoinHorizontal(lipgloss.Left, form, status)
 
 		footer := m.appBoundaryView(m.form.Help().ShortHelpView(m.form.KeyBinds()))
 		if len(errors) > 0 {

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/charmbracelet/huh v0.0.0-00010101000000-000000000000
 	github.com/charmbracelet/huh/spinner v0.0.0-00010101000000-000000000000
-	github.com/charmbracelet/lipgloss v1.0.0
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/log v0.4.1
 	github.com/charmbracelet/ssh v0.0.0-20250128164007-98fd5ae11894
 	github.com/charmbracelet/wish v1.4.6

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -30,8 +30,8 @@ github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/keygen v0.5.1 h1:zBkkYPtmKDVTw+cwUyY6ZwGDhRxXkEp0Oxs9sqMLqxI=
 github.com/charmbracelet/keygen v0.5.1/go.mod h1:zznJVmK/GWB6dAtjluqn2qsttiCBhA5MZSiwb80fcHw=
-github.com/charmbracelet/lipgloss v1.0.0 h1:O7VkGDvqEdGi93X+DeqsQ7PKHDgtQfF8j8/O2qFMQNg=
-github.com/charmbracelet/lipgloss v1.0.0/go.mod h1:U5fy9Z+C38obMs+T+tJqst9VGzlOYGj4ri9reL3qUlo=
+github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
+github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
 github.com/charmbracelet/log v0.4.1 h1:6AYnoHKADkghm/vt4neaNEXkxcXLSV2g1rdyFDOpTyk=
 github.com/charmbracelet/log v0.4.1/go.mod h1:pXgyTsqsVu4N9hGdHmQ0xEA4RsXof402LX9ZgiITn2I=
 github.com/charmbracelet/ssh v0.0.0-20250128164007-98fd5ae11894 h1:Ffon9TbltLGBsT6XE//YvNuu4OAaThXioqalhH11xEw=

--- a/examples/issue-275/main.go
+++ b/examples/issue-275/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
+)
+
+func main() {
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().Title("First"),
+			huh.NewInput().Title("Second"),
+			huh.NewInput().Title("Third"),
+			huh.NewInput().Title("Fourth"),
+			huh.NewInput().Title("Fifth"),
+			huh.NewInput().Title("Sixth"),
+			huh.NewInput().Title("Seventh"),
+			huh.NewInput().Title("Eigth"),
+			huh.NewInput().Title("Nineth"),
+			huh.NewInput().Title("Tenth"),
+		),
+	).WithProgramOptions(tea.WithAltScreen())
+	form.Run()
+}

--- a/field_confirm.go
+++ b/field_confirm.go
@@ -291,7 +291,8 @@ func (c *Confirm) View() string {
 	style := lipgloss.NewStyle().Width(renderWidth).Align(c.buttonAlignment)
 
 	sb.WriteString(style.Render(buttonsRow))
-	return styles.Base.Render(sb.String())
+	return styles.Base.Width(c.width).Height(c.height).
+		Render(sb.String())
 }
 
 // Run runs the confirm field in accessible mode.

--- a/field_confirm.go
+++ b/field_confirm.go
@@ -233,11 +233,12 @@ func (c *Confirm) activeStyles() *FieldStyles {
 // View renders the confirm field.
 func (c *Confirm) View() string {
 	styles := c.activeStyles()
+	maxWidth := c.width - styles.Base.GetHorizontalFrameSize()
 
 	var wroteHeader bool
 	var sb strings.Builder
 	if c.title.val != "" {
-		sb.WriteString(styles.Title.Render(wrap(c.title.val, c.width)))
+		sb.WriteString(styles.Title.Render(wrap(c.title.val, maxWidth)))
 		wroteHeader = true
 	}
 	if c.err != nil {
@@ -246,7 +247,7 @@ func (c *Confirm) View() string {
 	}
 
 	if c.description.val != "" {
-		description := styles.Description.Render(wrap(c.description.val, c.width))
+		description := styles.Description.Render(wrap(c.description.val, maxWidth))
 		if !c.inline && (c.description.val != "" || c.description.fn != nil) {
 			sb.WriteString("\n")
 		}

--- a/field_filepicker.go
+++ b/field_filepicker.go
@@ -260,13 +260,14 @@ func (f *FilePicker) activeStyles() *FieldStyles {
 // View renders the file field.
 func (f *FilePicker) View() string {
 	styles := f.activeStyles()
+	maxWidth := f.width - styles.Base.GetHorizontalFrameSize()
 
 	var sb strings.Builder
 	if f.title != "" {
-		sb.WriteString(styles.Title.Render(wrap(f.title, f.width)))
+		sb.WriteString(styles.Title.Render(wrap(f.title, maxWidth)))
 	}
 	if f.description != "" {
-		sb.WriteString(styles.Title.Render(wrap(f.description, f.width)) + "\n")
+		sb.WriteString(styles.Title.Render(wrap(f.description, maxWidth)) + "\n")
 	}
 	if f.picking {
 		sb.WriteString(strings.TrimSuffix(f.picker.View(), "\n"))

--- a/field_filepicker.go
+++ b/field_filepicker.go
@@ -278,7 +278,8 @@ func (f *FilePicker) View() string {
 			sb.WriteString(styles.TextInput.Placeholder.Render("No file selected."))
 		}
 	}
-	return styles.Base.Render(sb.String())
+	return styles.Base.Width(f.width).Height(f.height).
+		Render(sb.String())
 }
 
 func (f *FilePicker) setPicking(v bool) {

--- a/field_input.go
+++ b/field_input.go
@@ -374,6 +374,7 @@ func (i *Input) activeStyles() *FieldStyles {
 // View renders the input field.
 func (i *Input) View() string {
 	styles := i.activeStyles()
+	maxWidth := i.width - styles.Base.GetHorizontalFrameSize()
 
 	// NB: since the method is on a pointer receiver these are being mutated.
 	// Because this runs on every render this shouldn't matter in practice,
@@ -386,18 +387,18 @@ func (i *Input) View() string {
 
 	// Adjust text input size to its char limit if it fit in its width
 	if i.textinput.CharLimit > 0 {
-		i.textinput.Width = min(i.textinput.CharLimit, i.textinput.Width)
+		i.textinput.Width = min(i.textinput.CharLimit, i.textinput.Width, maxWidth)
 	}
 
 	var sb strings.Builder
 	if i.title.val != "" || i.title.fn != nil {
-		sb.WriteString(styles.Title.Render(wrap(i.title.val, i.width)))
+		sb.WriteString(styles.Title.Render(wrap(i.title.val, maxWidth)))
 		if !i.inline {
 			sb.WriteString("\n")
 		}
 	}
 	if i.description.val != "" || i.description.fn != nil {
-		sb.WriteString(styles.Description.Render(wrap(i.description.val, i.width)))
+		sb.WriteString(styles.Description.Render(wrap(i.description.val, maxWidth)))
 		if !i.inline {
 			sb.WriteString("\n")
 		}

--- a/field_input.go
+++ b/field_input.go
@@ -405,7 +405,8 @@ func (i *Input) View() string {
 	}
 	sb.WriteString(i.textinput.View())
 
-	return styles.Base.Render(sb.String())
+	return styles.Base.Width(i.width).Height(i.height).
+		Render(sb.String())
 }
 
 // Run runs the input field in accessible mode.

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -629,7 +629,8 @@ func (m *MultiSelect[T]) View() string {
 		sb.WriteString(m.descriptionView() + "\n")
 	}
 	sb.WriteString(m.viewport.View())
-	return styles.Base.Render(sb.String())
+	return styles.Base.Width(m.width).Height(m.height).
+		Render(sb.String())
 }
 
 func (m *MultiSelect[T]) printOptions() {

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -475,10 +475,15 @@ func (m *MultiSelect[T]) updateViewportHeight() {
 		return
 	}
 
-	const minHeight = 1
-	m.viewport.Height = max(minHeight, m.height-
-		lipgloss.Height(m.titleView())-
-		lipgloss.Height(m.descriptionView()))
+	offset := 0
+	if ss := m.titleView(); ss != "" {
+		offset += lipgloss.Height(ss)
+	}
+	if ss := m.descriptionView(); ss != "" {
+		offset += lipgloss.Height(ss)
+	}
+
+	m.viewport.Height = max(minHeight, m.height-offset)
 }
 
 // numSelected returns the total number of selected options.
@@ -550,6 +555,9 @@ func (m *MultiSelect[T]) titleView() string {
 }
 
 func (m *MultiSelect[T]) descriptionView() string {
+	if m.description.val == "" {
+		return ""
+	}
 	maxWidth := m.width - m.activeStyles().Base.GetHorizontalFrameSize()
 	return m.activeStyles().Description.Render(wrap(m.description.val, maxWidth))
 }

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -531,16 +531,17 @@ func (m *MultiSelect[T]) titleView() string {
 		return ""
 	}
 	var (
-		styles = m.activeStyles()
-		sb     = strings.Builder{}
+		styles   = m.activeStyles()
+		sb       = strings.Builder{}
+		maxWidth = m.width - styles.Base.GetHorizontalFrameSize()
 	)
 	if m.filtering {
 		sb.WriteString(m.filter.View())
 	} else if m.filter.Value() != "" {
-		sb.WriteString(styles.Title.Render(wrap(m.title.val, m.width)))
+		sb.WriteString(styles.Title.Render(wrap(m.title.val, maxWidth)))
 		sb.WriteString(styles.Description.Render("/" + m.filter.Value()))
 	} else {
-		sb.WriteString(styles.Title.Render(wrap(m.title.val, m.width)))
+		sb.WriteString(styles.Title.Render(wrap(m.title.val, maxWidth)))
 	}
 	if m.err != nil {
 		sb.WriteString(styles.ErrorIndicator.String())
@@ -549,7 +550,8 @@ func (m *MultiSelect[T]) titleView() string {
 }
 
 func (m *MultiSelect[T]) descriptionView() string {
-	return m.activeStyles().Description.Render(wrap(m.description.val, m.width))
+	maxWidth := m.width - m.activeStyles().Base.GetHorizontalFrameSize()
+	return m.activeStyles().Description.Render(wrap(m.description.val, maxWidth))
 }
 
 func (m *MultiSelect[T]) renderOption(option Option[T], cursor, selected bool) string {
@@ -567,7 +569,7 @@ func (m *MultiSelect[T]) renderOption(option Option[T], cursor, selected bool) s
 		parts = append(parts, styles.UnselectedPrefix.String())
 		parts = append(parts, styles.UnselectedOption.Render(option.Key))
 	}
-	return lipgloss.JoinHorizontal(lipgloss.Top, parts...)
+	return lipgloss.JoinHorizontal(lipgloss.Left, parts...)
 }
 
 func (m *MultiSelect[T]) optionsView() (string, int, int) {
@@ -624,8 +626,9 @@ func (m *MultiSelect[T]) View() string {
 
 func (m *MultiSelect[T]) printOptions() {
 	styles := m.activeStyles()
+	maxWidth := m.width - styles.Base.GetHorizontalFrameSize()
 	var sb strings.Builder
-	sb.WriteString(styles.Title.Render(wrap(m.title.val, m.width)))
+	sb.WriteString(styles.Title.Render(wrap(m.title.val, maxWidth)))
 	sb.WriteString("\n")
 
 	for i, option := range m.options.val {

--- a/field_note.go
+++ b/field_note.go
@@ -217,7 +217,7 @@ func (n *Note) activeStyles() *FieldStyles {
 // View renders the note field.
 func (n *Note) View() string {
 	styles := n.activeStyles()
-	maxWidth := n.width - styles.Base.GetHorizontalFrameSize()
+	maxWidth := n.width - styles.Card.GetHorizontalFrameSize()
 	sb := strings.Builder{}
 
 	if n.title.val != "" || n.title.fn != nil {
@@ -232,7 +232,7 @@ func (n *Note) View() string {
 		sb.WriteRune('\n')
 		sb.WriteString(styles.Next.Render(n.nextLabel))
 	}
-	return styles.Card.Height(n.height).Render(sb.String())
+	return styles.Card.Height(n.height).Width(n.width).Render(sb.String())
 }
 
 // Run runs the note field.

--- a/field_note.go
+++ b/field_note.go
@@ -232,7 +232,8 @@ func (n *Note) View() string {
 		sb.WriteRune('\n')
 		sb.WriteString(styles.Next.Render(n.nextLabel))
 	}
-	return styles.Card.Height(n.height).Width(n.width).Render(sb.String())
+	return styles.Card.Height(n.height).Width(n.width).
+		Render(sb.String())
 }
 
 // Run runs the note field.

--- a/field_note.go
+++ b/field_note.go
@@ -217,14 +217,15 @@ func (n *Note) activeStyles() *FieldStyles {
 // View renders the note field.
 func (n *Note) View() string {
 	styles := n.activeStyles()
+	maxWidth := n.width - styles.Base.GetHorizontalFrameSize()
 	sb := strings.Builder{}
 
 	if n.title.val != "" || n.title.fn != nil {
-		sb.WriteString(styles.NoteTitle.Render(wrap(n.title.val, n.width)))
+		sb.WriteString(styles.NoteTitle.Render(wrap(n.title.val, maxWidth)))
 	}
 	if n.description.val != "" || n.description.fn != nil {
 		sb.WriteRune('\n')
-		sb.WriteString(wrap(render(n.description.val), n.width))
+		sb.WriteString(wrap(render(n.description.val), maxWidth))
 		sb.WriteRune('\n')
 	}
 	if n.showNextButton {

--- a/field_select.go
+++ b/field_select.go
@@ -537,16 +537,17 @@ func (s *Select[T]) activeStyles() *FieldStyles {
 
 func (s *Select[T]) titleView() string {
 	var (
-		styles = s.activeStyles()
-		sb     = strings.Builder{}
+		styles   = s.activeStyles()
+		sb       = strings.Builder{}
+		maxWidth = s.width - styles.Base.GetHorizontalFrameSize()
 	)
 	if s.filtering {
 		sb.WriteString(s.filter.View())
 	} else if s.filter.Value() != "" && !s.inline {
-		sb.WriteString(styles.Title.Render(wrap(s.title.val, s.width)))
+		sb.WriteString(styles.Title.Render(wrap(s.title.val, maxWidth)))
 		sb.WriteString(styles.Description.Render("/" + s.filter.Value()))
 	} else {
-		sb.WriteString(styles.Title.Render(wrap(s.title.val, s.width)))
+		sb.WriteString(styles.Title.Render(wrap(s.title.val, maxWidth)))
 	}
 	if s.err != nil {
 		sb.WriteString(styles.ErrorIndicator.String())
@@ -555,7 +556,8 @@ func (s *Select[T]) titleView() string {
 }
 
 func (s *Select[T]) descriptionView() string {
-	return s.activeStyles().Description.Render(wrap(s.description.val, s.width))
+	maxWidth := s.width - s.activeStyles().Base.GetHorizontalFrameSize()
+	return s.activeStyles().Description.Render(wrap(s.description.val, maxWidth))
 }
 
 func (s *Select[T]) optionsView() (string, int, int) {
@@ -608,22 +610,23 @@ func (s *Select[T]) optionsView() (string, int, int) {
 
 func (s *Select[T]) renderOption(option Option[T], selected bool) string {
 	var (
-		styles  = s.activeStyles()
-		cursor  = styles.SelectSelector.String()
-		cursorW = lipgloss.Width(cursor)
+		styles   = s.activeStyles()
+		cursor   = styles.SelectSelector.String()
+		cursorW  = lipgloss.Width(cursor)
+		maxWidth = s.width - s.activeStyles().Base.GetHorizontalFrameSize() - cursorW
 	)
 
-	key := wrap(option.Key, s.width-cursorW)
+	key := wrap(option.Key, maxWidth)
 
 	if selected {
 		return lipgloss.JoinHorizontal(
-			lipgloss.Top,
+			lipgloss.Left,
 			cursor,
 			styles.SelectedOption.Render(key),
 		)
 	}
 	return lipgloss.JoinHorizontal(
-		lipgloss.Top,
+		lipgloss.Left,
 		strings.Repeat(" ", cursorW),
 		styles.UnselectedOption.Render(key),
 	)

--- a/field_select.go
+++ b/field_select.go
@@ -582,14 +582,14 @@ func (s *Select[T]) optionsView() (string, int, int) {
 	}
 
 	if s.inline {
-		sb.WriteString(styles.PrevIndicator.Faint(s.selected <= 0).String())
+		prev := styles.PrevIndicator.Faint(s.selected <= 0).String()
+		next := styles.NextIndicator.Faint(s.selected == len(s.filteredOptions)-1).String()
+		opt := styles.TextInput.Placeholder.Render("No matches")
 		if len(s.filteredOptions) > 0 {
-			sb.WriteString(styles.SelectedOption.Render(s.filteredOptions[s.selected].Key))
-		} else {
-			sb.WriteString(styles.TextInput.Placeholder.Render("No matches"))
+			opt = styles.SelectedOption.Render(s.filteredOptions[s.selected].Key)
 		}
-		sb.WriteString(styles.NextIndicator.Faint(s.selected == len(s.filteredOptions)-1).String())
-		return sb.String(), -1, 1
+		ss := lipgloss.JoinHorizontal(lipgloss.Left, prev, opt, next)
+		return lipgloss.NewStyle().Width(s.width).Render(ss), -1, 1
 	}
 
 	var cursorOffset int

--- a/field_select.go
+++ b/field_select.go
@@ -582,14 +582,19 @@ func (s *Select[T]) optionsView() (string, int, int) {
 	}
 
 	if s.inline {
-		prev := styles.PrevIndicator.Faint(s.selected <= 0).String()
-		next := styles.NextIndicator.Faint(s.selected == len(s.filteredOptions)-1).String()
-		opt := styles.TextInput.Placeholder.Render("No matches")
+		option := styles.TextInput.Placeholder.Render("No matches")
 		if len(s.filteredOptions) > 0 {
-			opt = styles.SelectedOption.Render(s.filteredOptions[s.selected].Key)
+			option = styles.SelectedOption.Render(s.filteredOptions[s.selected].Key)
 		}
-		ss := lipgloss.JoinHorizontal(lipgloss.Left, prev, opt, next)
-		return lipgloss.NewStyle().Width(s.width).Render(ss), -1, 1
+		return lipgloss.NewStyle().
+				Width(s.width).
+				Render(lipgloss.JoinHorizontal(
+					lipgloss.Left,
+					styles.PrevIndicator.Faint(s.selected <= 0).String(),
+					option,
+					styles.NextIndicator.Faint(s.selected == len(s.filteredOptions)-1).String(),
+				)),
+			-1, 1
 	}
 
 	var cursorOffset int

--- a/field_select.go
+++ b/field_select.go
@@ -655,7 +655,8 @@ func (s *Select[T]) View() string {
 	if s.description.val != "" || s.description.fn != nil {
 		parts = append(parts, s.descriptionView())
 	}
-	return styles.Base.Render(lipgloss.JoinVertical(lipgloss.Top, parts...))
+	return styles.Base.Width(s.width).Height(s.height).
+		Render(lipgloss.JoinVertical(lipgloss.Top, parts...))
 }
 
 // clearFilter clears the value of the filter.

--- a/field_text.go
+++ b/field_text.go
@@ -386,16 +386,17 @@ func (t *Text) View() string {
 	t.textarea.Cursor.Style = styles.TextInput.Cursor
 	t.textarea.Cursor.TextStyle = styles.TextInput.CursorText
 
+	maxWidth := t.width - styles.Base.GetHorizontalFrameSize()
 	var sb strings.Builder
 	if t.title.val != "" || t.title.fn != nil {
-		sb.WriteString(styles.Title.Render(wrap(t.title.val, t.width)))
+		sb.WriteString(styles.Title.Render(wrap(t.title.val, maxWidth)))
 		if t.err != nil {
 			sb.WriteString(styles.ErrorIndicator.String())
 		}
 		sb.WriteString("\n")
 	}
 	if t.description.val != "" || t.description.fn != nil {
-		sb.WriteString(styles.Description.Render(wrap(t.description.val, t.width)))
+		sb.WriteString(styles.Description.Render(wrap(t.description.val, maxWidth)))
 		sb.WriteString("\n")
 	}
 	sb.WriteString(t.textarea.View())

--- a/field_text.go
+++ b/field_text.go
@@ -387,21 +387,20 @@ func (t *Text) View() string {
 	t.textarea.Cursor.TextStyle = styles.TextInput.CursorText
 
 	maxWidth := t.width - styles.Base.GetHorizontalFrameSize()
-	var sb strings.Builder
+	var parts []string
 	if t.title.val != "" || t.title.fn != nil {
-		sb.WriteString(styles.Title.Render(wrap(t.title.val, maxWidth)))
+		header := styles.Title.Render(wrap(t.title.val, maxWidth))
 		if t.err != nil {
-			sb.WriteString(styles.ErrorIndicator.String())
+			header += styles.ErrorIndicator.String()
 		}
-		sb.WriteString("\n")
+		parts = append(parts, header)
 	}
 	if t.description.val != "" || t.description.fn != nil {
-		sb.WriteString(styles.Description.Render(wrap(t.description.val, maxWidth)))
-		sb.WriteString("\n")
+		parts = append(parts, styles.Description.Render(wrap(t.description.val, maxWidth)))
 	}
-	sb.WriteString(t.textarea.View())
+	parts = append(parts, t.textarea.View())
 
-	return styles.Base.Render(sb.String())
+	return styles.Base.Render(lipgloss.JoinVertical(lipgloss.Top, parts...))
 }
 
 // Run runs the text field.

--- a/form.go
+++ b/form.go
@@ -523,15 +523,27 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			group.WithWidth(width)
 			return true
 		})
+
 		if f.height > 0 {
 			break
 		}
+
+		// get the max allowed height, and use it, so all groups have the same
+		// height.
+		normalizedHeight := 0
 		f.selector.Range(func(_ int, group *Group) bool {
-			if group.fullHeight() > msg.Height {
-				group.WithHeight(msg.Height)
+			gh := max(group.height, min(group.rawHeight(), msg.Height))
+			if gh > normalizedHeight {
+				normalizedHeight = gh
 			}
 			return true
 		})
+
+		f.selector.Range(func(_ int, group *Group) bool {
+			group.WithHeight(normalizedHeight)
+			return true
+		})
+
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, f.keymap.Quit):

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/catppuccin/go v0.3.0
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.4
-	github.com/charmbracelet/lipgloss v1.0.0
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.8.0
 	github.com/charmbracelet/x/cellbuf v0.0.13
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/charmbracelet/bubbletea v1.3.4 h1:kCg7B+jSCFPLYRA52SDZjr51kG/fMUEoPoZ
 github.com/charmbracelet/bubbletea v1.3.4/go.mod h1:dtcUCyCGEX3g9tosuYiut3MXgY/Jsv9nKVdibKKRRXo=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc/go.mod h1:X4/0JoqgTIPSFcRA/P6INZzIuyqdFY5rm8tb41s9okk=
-github.com/charmbracelet/lipgloss v1.0.0 h1:O7VkGDvqEdGi93X+DeqsQ7PKHDgtQfF8j8/O2qFMQNg=
-github.com/charmbracelet/lipgloss v1.0.0/go.mod h1:U5fy9Z+C38obMs+T+tJqst9VGzlOYGj4ri9reL3qUlo=
+github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
+github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
 github.com/charmbracelet/x/ansi v0.8.0 h1:9GTq3xq9caJW8ZrBTe0LIe2fvfLR/bYXKTx2llXn7xE=
 github.com/charmbracelet/x/ansi v0.8.0/go.mod h1:wdYl/ONOLHLIVmQaxbIYEC/cRKOQyjTkowiI4blgS9Q=
 github.com/charmbracelet/x/cellbuf v0.0.13 h1:/KBBKHuVRbq1lYx5BzEHBAFBP8VcQzJejZ/IA3iR28k=

--- a/group.go
+++ b/group.go
@@ -126,11 +126,12 @@ func (g *Group) WithWidth(width int) *Group {
 // WithHeight sets the height on a group.
 func (g *Group) WithHeight(height int) *Group {
 	g.height = height
-	g.viewport.Height = g.height - lipgloss.Height(g.Footer()+g.Header())
+	h := height - g.nonContentHeight()
+	g.viewport.Height = h
 	g.selector.Range(func(_ int, field Field) bool {
 		// A field height must not exceed the form height.
-		if g.height < lipgloss.Height(field.View()) {
-			field.WithHeight(g.height)
+		if h < lipgloss.Height(field.View()) {
+			field.WithHeight(h)
 		}
 		return true
 	})
@@ -338,17 +339,21 @@ func (g *Group) Header() string {
 	return lipgloss.JoinVertical(lipgloss.Top, parts...)
 }
 
-// height returns the full height of the group, without using a viewport.
-func (g *Group) rawHeight() int {
+// nonContentHeight returns the height of the footer + header.
+func (g *Group) nonContentHeight() int {
 	var parts []string
 	if s := g.Header(); s != "" {
 		parts = append(parts, s)
 	}
-	parts = append(parts, g.Content())
 	if s := g.Footer(); s != "" {
 		parts = append(parts, s)
 	}
 	return lipgloss.Height(lipgloss.JoinVertical(lipgloss.Top, parts...))
+}
+
+// rawHeight returns the full height of the group, without using a viewport.
+func (g *Group) rawHeight() int {
+	return lipgloss.Height(g.Content()) + g.nonContentHeight()
 }
 
 // View renders the group.

--- a/group.go
+++ b/group.go
@@ -115,6 +115,7 @@ func (g *Group) WithKeyMap(k *KeyMap) *Group {
 func (g *Group) WithWidth(width int) *Group {
 	g.width = width
 	g.viewport.Width = width
+	g.help.Width = width
 	g.selector.Range(func(_ int, field Field) bool {
 		field.WithWidth(width)
 		return true
@@ -378,16 +379,14 @@ func (g *Group) Footer() string {
 	}
 	if g.showErrors {
 		for _, err := range errors {
-			parts = append(parts, g.getTheme().Focused.ErrorMessage.Render(err.Error()))
+			parts = append(parts, wrap(
+				g.getTheme().Focused.ErrorMessage.Render(err.Error()),
+				g.width,
+			))
 		}
 	}
-	return g.styles().Base.Render(
-		wrap(
-			lipgloss.JoinVertical(
-				lipgloss.Top,
-				parts...,
-			),
-			g.width,
-		),
-	)
+	return g.styles().Base.Render(lipgloss.JoinVertical(
+		lipgloss.Top,
+		parts...,
+	))
 }

--- a/group.go
+++ b/group.go
@@ -274,7 +274,7 @@ func (g *Group) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		g.WithWidth(max(g.width, msg.Width))
-		g.WithHeight(max(g.height, msg.Height))
+		g.WithHeight(max(g.height, min(g.fullHeight(), msg.Height)))
 	case nextFieldMsg:
 		cmds = append(cmds, g.nextField()...)
 	case prevFieldMsg:

--- a/group.go
+++ b/group.go
@@ -274,7 +274,7 @@ func (g *Group) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		g.WithWidth(max(g.width, msg.Width))
-		g.WithHeight(max(g.height, min(g.fullHeight(), msg.Height)))
+		g.WithHeight(max(g.height, msg.Height))
 	case nextFieldMsg:
 		cmds = append(cmds, g.nextField()...)
 	case prevFieldMsg:

--- a/huh_test.go
+++ b/huh_test.go
@@ -990,7 +990,7 @@ var titleAndDescTests = map[string]struct {
 }{
 	"Group": {
 		NewGroup(NewInput()),
-		3, // \n> \n
+		2, // > \n
 		NewGroup(NewInput()).Title(title),
 		NewGroup(NewInput()).Description(description),
 	},

--- a/layout.go
+++ b/layout.go
@@ -80,7 +80,7 @@ func (l *layoutColumns) View(f *Form) string {
 
 	return lipgloss.JoinVertical(lipgloss.Left,
 		header,
-		lipgloss.JoinHorizontal(lipgloss.Top, columns...),
+		lipgloss.JoinHorizontal(lipgloss.Left, columns...),
 		footer,
 	)
 }
@@ -158,7 +158,7 @@ func (l *layoutGrid) View(f *Form) string {
 		for _, group := range row {
 			columns = append(columns, group.Content())
 		}
-		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, columns...))
+		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Left, columns...))
 	}
 	footer := f.selector.Selected().Footer()
 

--- a/layout.go
+++ b/layout.go
@@ -1,8 +1,6 @@
 package huh
 
 import (
-	"strings"
-
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -97,12 +95,11 @@ func (l *layoutStack) View(f *Form) string {
 		columns = append(columns, group.Content())
 		return true
 	})
-	footer := f.selector.Selected().Footer()
 
-	var view strings.Builder
-	view.WriteString(strings.Join(columns, "\n"))
-	view.WriteString(footer)
-	return view.String()
+	if footer := f.selector.Selected().Footer(); footer != "" {
+		columns = append(columns, footer)
+	}
+	return lipgloss.JoinVertical(lipgloss.Top, columns...)
 }
 
 func (l *layoutStack) GroupWidth(_ *Form, _ *Group, w int) int {
@@ -162,7 +159,10 @@ func (l *layoutGrid) View(f *Form) string {
 	}
 	footer := f.selector.Selected().Footer()
 
-	return lipgloss.JoinVertical(lipgloss.Left, strings.Join(rows, "\n"), footer)
+	return lipgloss.JoinVertical(
+		lipgloss.Top,
+		append(rows, footer)...,
+	)
 }
 
 func (l *layoutGrid) GroupWidth(_ *Form, _ *Group, w int) int {

--- a/theme.go
+++ b/theme.go
@@ -96,7 +96,7 @@ func ThemeBase() *Theme {
 
 	// Focused styles.
 	t.Focused.Base = lipgloss.NewStyle().PaddingLeft(1).BorderStyle(lipgloss.ThickBorder()).BorderLeft(true)
-	t.Focused.Card = lipgloss.NewStyle().PaddingLeft(1)
+	t.Focused.Card = t.Focused.Base
 	t.Focused.ErrorIndicator = lipgloss.NewStyle().SetString(" *")
 	t.Focused.ErrorMessage = lipgloss.NewStyle().SetString(" *")
 	t.Focused.SelectSelector = lipgloss.NewStyle().SetString("> ")
@@ -114,6 +114,7 @@ func ThemeBase() *Theme {
 	// Blurred styles.
 	t.Blurred = t.Focused
 	t.Blurred.Base = t.Blurred.Base.BorderStyle(lipgloss.HiddenBorder())
+	t.Blurred.Card = t.Blurred.Base
 	t.Blurred.MultiSelectSelector = lipgloss.NewStyle().SetString("  ")
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
@@ -135,6 +136,7 @@ func ThemeCharm() *Theme {
 	)
 
 	t.Focused.Base = t.Focused.Base.BorderForeground(lipgloss.Color("238"))
+	t.Focused.Card = t.Focused.Base
 	t.Focused.Title = t.Focused.Title.Foreground(indigo).Bold(true)
 	t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(indigo).Bold(true).MarginBottom(1)
 	t.Focused.Directory = t.Focused.Directory.Foreground(indigo)
@@ -160,6 +162,7 @@ func ThemeCharm() *Theme {
 
 	t.Blurred = t.Focused
 	t.Blurred.Base = t.Focused.Base.BorderStyle(lipgloss.HiddenBorder())
+	t.Blurred.Card = t.Blurred.Base
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
 
@@ -184,6 +187,7 @@ func ThemeDracula() *Theme {
 	)
 
 	t.Focused.Base = t.Focused.Base.BorderForeground(selection)
+	t.Focused.Card = t.Focused.Base
 	t.Focused.Title = t.Focused.Title.Foreground(purple)
 	t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(purple)
 	t.Focused.Description = t.Focused.Description.Foreground(comment)
@@ -209,6 +213,7 @@ func ThemeDracula() *Theme {
 
 	t.Blurred = t.Focused
 	t.Blurred.Base = t.Blurred.Base.BorderStyle(lipgloss.HiddenBorder())
+	t.Blurred.Card = t.Blurred.Base
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
 
@@ -222,6 +227,7 @@ func ThemeBase16() *Theme {
 	t := ThemeBase()
 
 	t.Focused.Base = t.Focused.Base.BorderForeground(lipgloss.Color("8"))
+	t.Focused.Card = t.Focused.Base
 	t.Focused.Title = t.Focused.Title.Foreground(lipgloss.Color("6"))
 	t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(lipgloss.Color("6"))
 	t.Focused.Directory = t.Focused.Directory.Foreground(lipgloss.Color("6"))
@@ -245,6 +251,7 @@ func ThemeBase16() *Theme {
 
 	t.Blurred = t.Focused
 	t.Blurred.Base = t.Blurred.Base.BorderStyle(lipgloss.HiddenBorder())
+	t.Blurred.Card = t.Blurred.Base
 	t.Blurred.NoteTitle = t.Blurred.NoteTitle.Foreground(lipgloss.Color("8"))
 	t.Blurred.Title = t.Blurred.NoteTitle.Foreground(lipgloss.Color("8"))
 
@@ -281,6 +288,7 @@ func ThemeCatppuccin() *Theme {
 	)
 
 	t.Focused.Base = t.Focused.Base.BorderForeground(subtext1)
+	t.Focused.Card = t.Focused.Base
 	t.Focused.Title = t.Focused.Title.Foreground(mauve)
 	t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(mauve)
 	t.Focused.Directory = t.Focused.Directory.Foreground(mauve)
@@ -305,6 +313,7 @@ func ThemeCatppuccin() *Theme {
 
 	t.Blurred = t.Focused
 	t.Blurred.Base = t.Blurred.Base.BorderStyle(lipgloss.HiddenBorder())
+	t.Blurred.Card = t.Blurred.Base
 
 	t.Help.Ellipsis = t.Help.Ellipsis.Foreground(subtext0)
 	t.Help.ShortKey = t.Help.ShortKey.Foreground(subtext0)


### PR DESCRIPTION
this fixes many rendering issue:

- uses the height of the taller group for the entire form unless another one is specified
- properly join lines with lipgloss (IMHO easier to reason about)
- avoid adding empty lines when not needed
- properly account for title/description when calculating heights
- properly account for framesize when calculating widths
- properly set help width 
- properly use the set theme when showing group errors
- fields actually use their height and height when rendering - this improves grid layout
- fixed note styles (will use base by default)
- maintain constant width when rendering an inline select

fixes #275 (and probably more)
closes https://github.com/charmbracelet/huh/issues/486

### main:

https://github.com/user-attachments/assets/a2fdabef-3869-4a80-8062-b51e8edccc04

### v0.6.0


https://github.com/user-attachments/assets/bb99b518-c6cc-4c4a-9ff6-ae266ec297b5


### this branch

https://github.com/user-attachments/assets/a55cea61-90f2-4de8-bc6f-13295795350d


