### PR TITLE
feat(input): dynamic default values

### DIFF
--- a/examples/dynamic/dynamic-default/main.go
+++ b/examples/dynamic/dynamic-default/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+)
+
+func main() {
+
+	var name, id, directory string
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().Title("Project name").Value(&name).Validate(huh.ValidateNotEmpty()),
+			huh.NewInput().Title("Project ID").Value(&id).DefaultFunc(func() string {
+				return strings.ReplaceAll(strings.ToLower(name), "/", "-")
+			}, &name),
+			huh.NewInput().Title("Project directory").Value(&directory).DefaultFunc(func() string {
+				if id == "" {
+					return "~/projects/<Project ID>"
+				}
+				return "~/projects/" + id
+			}, &id),
+		),
+	)
+
+	if err := form.Run(); err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println("Project Name: ", name)
+	fmt.Println("Project ID: ", id)
+	fmt.Println("Directory: ", directory)
+}

--- a/examples/dynamic/dynamic-default/main.go
+++ b/examples/dynamic/dynamic-default/main.go
@@ -13,7 +13,7 @@ func main() {
 
 	form := huh.NewForm(
 		huh.NewGroup(
-			huh.NewInput().Title("Project name").Value(&name).Validate(huh.ValidateNotEmpty()),
+			huh.NewInput().Title("Project name").Value(&name).Placeholder("<Placeholder>").Validate(huh.ValidateNotEmpty()),
 			huh.NewInput().Title("Project ID").Value(&id).DefaultFunc(func() string {
 				return strings.ReplaceAll(strings.ToLower(name), "/", "-")
 			}, &name),

--- a/field_input.go
+++ b/field_input.go
@@ -409,7 +409,11 @@ func (i *Input) View() string {
 	// NB: since the method is on a pointer receiver these are being mutated.
 	// Because this runs on every render this shouldn't matter in practice,
 	// however.
-	i.textinput.PlaceholderStyle = styles.TextInput.Placeholder
+	if i.placeholderIsDefault {
+		i.textinput.PlaceholderStyle = styles.TextInput.DefaultValue
+	} else {
+		i.textinput.PlaceholderStyle = styles.TextInput.Placeholder
+	}
 	i.textinput.PromptStyle = styles.TextInput.Prompt
 	i.textinput.Cursor.Style = styles.TextInput.Cursor
 	i.textinput.Cursor.TextStyle = styles.TextInput.CursorText

--- a/theme.go
+++ b/theme.go
@@ -69,11 +69,12 @@ type FieldStyles struct {
 
 // TextInputStyles are the styles for text inputs.
 type TextInputStyles struct {
-	Cursor      lipgloss.Style
-	CursorText  lipgloss.Style
-	Placeholder lipgloss.Style
-	Prompt      lipgloss.Style
-	Text        lipgloss.Style
+	Cursor       lipgloss.Style
+	CursorText   lipgloss.Style
+	Placeholder  lipgloss.Style
+	DefaultValue lipgloss.Style
+	Prompt       lipgloss.Style
+	Text         lipgloss.Style
 }
 
 const (
@@ -108,6 +109,7 @@ func ThemeBase() *Theme {
 	t.Focused.FocusedButton = button.Foreground(lipgloss.Color("0")).Background(lipgloss.Color("7"))
 	t.Focused.BlurredButton = button.Foreground(lipgloss.Color("7")).Background(lipgloss.Color("0"))
 	t.Focused.TextInput.Placeholder = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	t.Focused.TextInput.DefaultValue = lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
 
 	t.Help = help.New().Styles
 
@@ -158,6 +160,7 @@ func ThemeCharm() *Theme {
 
 	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(green)
 	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(lipgloss.AdaptiveColor{Light: "248", Dark: "238"})
+	t.Focused.TextInput.DefaultValue = t.Focused.TextInput.DefaultValue.Foreground(lipgloss.AdaptiveColor{Light: "243", Dark: "248"})
 	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(fuchsia)
 
 	t.Blurred = t.Focused
@@ -209,6 +212,7 @@ func ThemeDracula() *Theme {
 
 	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(yellow)
 	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(comment)
+	t.Focused.TextInput.DefaultValue = t.Focused.TextInput.DefaultValue.Foreground(yellow)
 	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(yellow)
 
 	t.Blurred = t.Focused
@@ -247,6 +251,7 @@ func ThemeBase16() *Theme {
 
 	t.Focused.TextInput.Cursor.Foreground(lipgloss.Color("5"))
 	t.Focused.TextInput.Placeholder.Foreground(lipgloss.Color("8"))
+	t.Focused.TextInput.DefaultValue.Foreground(lipgloss.Color("7"))
 	t.Focused.TextInput.Prompt.Foreground(lipgloss.Color("3"))
 
 	t.Blurred = t.Focused
@@ -278,6 +283,7 @@ func ThemeCatppuccin() *Theme {
 		text     = lipgloss.AdaptiveColor{Light: light.Text().Hex, Dark: dark.Text().Hex}
 		subtext1 = lipgloss.AdaptiveColor{Light: light.Subtext1().Hex, Dark: dark.Subtext1().Hex}
 		subtext0 = lipgloss.AdaptiveColor{Light: light.Subtext0().Hex, Dark: dark.Subtext0().Hex}
+		overlay2 = lipgloss.AdaptiveColor{Light: light.Overlay2().Hex, Dark: dark.Overlay2().Hex}
 		overlay1 = lipgloss.AdaptiveColor{Light: light.Overlay1().Hex, Dark: dark.Overlay1().Hex}
 		overlay0 = lipgloss.AdaptiveColor{Light: light.Overlay0().Hex, Dark: dark.Overlay0().Hex}
 		green    = lipgloss.AdaptiveColor{Light: light.Green().Hex, Dark: dark.Green().Hex}
@@ -309,6 +315,7 @@ func ThemeCatppuccin() *Theme {
 
 	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(cursor)
 	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(overlay0)
+	t.Focused.TextInput.DefaultValue = t.Focused.TextInput.DefaultValue.Foreground(overlay2)
 	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(pink)
 
 	t.Blurred = t.Focused


### PR DESCRIPTION
Default values are a special type of placeholder that is treated as the field's actual value when the value would otherwise be empty. The existing default value mechanism — the field's "initial value" — is regularly overridden by the value read from the textinput bubble, which makes it effectively static.

It might be possible to make the "initial value" mechanism more dynamic, leveraging the placeholder for default values instead as this PR does allows dynamic defaults to be more consistent with the rest of the dynamic forms API and it also yields a slightly better user experience by allowing default values to be treated and themed differently than user-entered values.

Fixes the issue raised in https://github.com/charmbracelet/huh/discussions/582#discussioncomment-12708978.

The 2nd commit updates the themes to display default values differently than placeholders. This isn't strictly necessary, but since they behave slightly differently, they probably should look different too.