### PR TITLE
feat: make Field.RunAccessible public, deprecate Field.WithAccessible

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -35,7 +35,7 @@ type Confirm struct {
 	width           int
 	height          int
 	inline          bool
-	accessible      bool
+	accessible      bool // Deprecated: use RunAccessible instead.
 	theme           *Theme
 	keymap          ConfirmKeyMap
 	buttonAlignment lipgloss.Position
@@ -285,10 +285,7 @@ func (c *Confirm) View() string {
 	promptWidth := lipgloss.Width(sb.String())
 	buttonsWidth := lipgloss.Width(buttonsRow)
 
-	renderWidth := promptWidth
-	if buttonsWidth > renderWidth {
-		renderWidth = buttonsWidth
-	}
+	renderWidth := max(buttonsWidth, promptWidth)
 
 	style := lipgloss.NewStyle().Width(renderWidth).Align(c.buttonAlignment)
 
@@ -299,14 +296,14 @@ func (c *Confirm) View() string {
 
 // Run runs the confirm field in accessible mode.
 func (c *Confirm) Run() error {
-	if c.accessible {
-		return c.runAccessible(os.Stdout, os.Stdin)
+	if c.accessible { // TODO: remove in a future release.
+		return c.RunAccessible(os.Stdout, os.Stdin)
 	}
 	return Run(c)
 }
 
-// runAccessible runs the confirm field in accessible mode.
-func (c *Confirm) runAccessible(w io.Writer, r io.Reader) error {
+// RunAccessible runs the confirm field in accessible mode.
+func (c *Confirm) RunAccessible(w io.Writer, r io.Reader) error {
 	styles := c.activeStyles()
 	defaultValue := c.GetValue().(bool)
 	opts := "[y/N]"
@@ -343,6 +340,9 @@ func (c *Confirm) WithKeyMap(k *KeyMap) Field {
 }
 
 // WithAccessible sets the accessible mode of the confirm field.
+//
+// Deprecated: you may now call [Confirm.RunAccessible] directly to run the
+// field in accessible mode.
 func (c *Confirm) WithAccessible(accessible bool) Field {
 	c.accessible = accessible
 	return c

--- a/field_filepicker.go
+++ b/field_filepicker.go
@@ -36,7 +36,7 @@ type FilePicker struct {
 	// options
 	width      int
 	height     int
-	accessible bool
+	accessible bool // Deprecated: use RunAccessible instead.
 	theme      *Theme
 	keymap     FilePickerKeyMap
 }
@@ -308,14 +308,14 @@ func (f *FilePicker) setPicking(v bool) {
 
 // Run runs the file field.
 func (f *FilePicker) Run() error {
-	if f.accessible {
-		return f.runAccessible(os.Stdout, os.Stdin)
+	if f.accessible { // TODO: remove in a future release.
+		return f.RunAccessible(os.Stdout, os.Stdin)
 	}
 	return Run(f)
 }
 
-// runAccessible runs an accessible file field.
-func (f *FilePicker) runAccessible(w io.Writer, r io.Reader) error {
+// RunAccessible runs an accessible file field.
+func (f *FilePicker) RunAccessible(w io.Writer, r io.Reader) error {
 	styles := f.activeStyles()
 	prompt := styles.Title.
 		PaddingRight(1).
@@ -403,6 +403,9 @@ func (f *FilePicker) WithKeyMap(k *KeyMap) Field {
 }
 
 // WithAccessible sets the accessible mode of the file field.
+//
+// Deprecated: you may now call [FilePicker.RunAccessible] directly to run the
+// field in accessible mode.
 func (f *FilePicker) WithAccessible(accessible bool) Field {
 	f.accessible = accessible
 	return f

--- a/field_input.go
+++ b/field_input.go
@@ -38,9 +38,9 @@ type Input struct {
 	err      error
 	focused  bool
 
-	accessible bool
+	accessible bool // Deprecated: use RunAccessible instead.
 	width      int
-	height     int // not really used anywhere
+	height     int
 
 	theme  *Theme
 	keymap InputKeyMap
@@ -417,8 +417,8 @@ func (i *Input) View() string {
 
 // Run runs the input field in accessible mode.
 func (i *Input) Run() error {
-	if i.accessible {
-		return i.runAccessible(os.Stdout, os.Stdin)
+	if i.accessible { // TODO: remove in a future release.
+		return i.RunAccessible(os.Stdout, os.Stdin)
 	}
 	return i.run()
 }
@@ -428,8 +428,8 @@ func (i *Input) run() error {
 	return Run(i)
 }
 
-// runAccessible runs the input field in accessible mode.
-func (i *Input) runAccessible(w io.Writer, r io.Reader) error {
+// RunAccessible runs the input field in accessible mode.
+func (i *Input) RunAccessible(w io.Writer, r io.Reader) error {
 	styles := i.activeStyles()
 	validator := func(input string) error {
 		if i.textinput.CharLimit > 0 && len(input) > i.textinput.CharLimit {
@@ -470,6 +470,9 @@ func (i *Input) WithKeyMap(k *KeyMap) Field {
 }
 
 // WithAccessible sets the accessible mode of the input field.
+//
+// Deprecated: you may now call [Input.RunAccessible] directly to run the
+// field in accessible mode.
 func (i *Input) WithAccessible(accessible bool) Field {
 	i.accessible = accessible
 	return i

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -47,7 +47,7 @@ type MultiSelect[T comparable] struct {
 
 	// options
 	width      int
-	accessible bool
+	accessible bool // Deprecated: use RunAccessible instead.
 	theme      *Theme
 	keymap     MultiSelectKeyMap
 }
@@ -700,14 +700,14 @@ func (m *MultiSelect[T]) setSelectAllHelp() {
 
 // Run runs the multi-select field.
 func (m *MultiSelect[T]) Run() error {
-	if m.accessible {
-		return m.runAccessible(os.Stdout, os.Stdin)
+	if m.accessible { // TODO: remove in a future release.
+		return m.RunAccessible(os.Stdout, os.Stdin)
 	}
 	return Run(m)
 }
 
-// runAccessible() runs the multi-select field in accessible mode.
-func (m *MultiSelect[T]) runAccessible(w io.Writer, r io.Reader) error {
+// RunAccessible() runs the multi-select field in accessible mode.
+func (m *MultiSelect[T]) RunAccessible(w io.Writer, r io.Reader) error {
 	styles := m.activeStyles()
 	title := styles.Title.
 		PaddingRight(1).
@@ -774,6 +774,9 @@ func (m *MultiSelect[T]) WithKeyMap(k *KeyMap) Field {
 }
 
 // WithAccessible sets the accessible mode of the multi-select field.
+//
+// Deprecated: you may now call [MultiSelect.RunAccessible] directly to run the
+// field in accessible mode.
 func (m *MultiSelect[T]) WithAccessible(accessible bool) Field {
 	m.accessible = accessible
 	return m

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -706,7 +706,7 @@ func (m *MultiSelect[T]) Run() error {
 	return Run(m)
 }
 
-// RunAccessible() runs the multi-select field in accessible mode.
+// RunAccessible runs the multi-select field in accessible mode.
 func (m *MultiSelect[T]) RunAccessible(w io.Writer, r io.Reader) error {
 	styles := m.activeStyles()
 	title := styles.Title.

--- a/field_note.go
+++ b/field_note.go
@@ -26,7 +26,7 @@ type Note struct {
 	showNextButton bool
 	skip           bool
 
-	accessible bool
+	accessible bool // Deprecated: use RunAccessible instead.
 	height     int
 	width      int
 
@@ -242,14 +242,14 @@ func (n *Note) View() string {
 
 // Run runs the note field.
 func (n *Note) Run() error {
-	if n.accessible {
-		return n.runAccessible(os.Stdout, os.Stdin)
+	if n.accessible { // TODO: remove in a future release.
+		return n.RunAccessible(os.Stdout, os.Stdin)
 	}
 	return Run(n)
 }
 
-// runAccessible runs an accessible note field.
-func (n *Note) runAccessible(w io.Writer, _ io.Reader) error {
+// RunAccessible runs an accessible note field.
+func (n *Note) RunAccessible(w io.Writer, _ io.Reader) error {
 	styles := n.activeStyles()
 	if n.title.val != "" {
 		_, _ = fmt.Fprintln(w, styles.Title.Render(n.title.val))
@@ -276,6 +276,9 @@ func (n *Note) WithKeyMap(k *KeyMap) Field {
 }
 
 // WithAccessible sets the accessible mode of the note field.
+//
+// Deprecated: you may now call [Note.RunAccessible] directly to run the
+// field in accessible mode.
 func (n *Note) WithAccessible(accessible bool) Field {
 	n.accessible = accessible
 	return n

--- a/field_select.go
+++ b/field_select.go
@@ -52,7 +52,7 @@ type Select[T comparable] struct {
 	inline     bool
 	width      int
 	height     int
-	accessible bool
+	accessible bool // Deprecated: use RunAccessible instead.
 	theme      *Theme
 	keymap     SelectKeyMap
 }
@@ -701,14 +701,14 @@ func (s *Select[T]) filterFunc(option string) bool {
 
 // Run runs the select field.
 func (s *Select[T]) Run() error {
-	if s.accessible {
-		return s.runAccessible(os.Stdout, os.Stdin)
+	if s.accessible { // TODO: remove in a future release.
+		return s.RunAccessible(os.Stdout, os.Stdin)
 	}
 	return Run(s)
 }
 
-// runAccessible runs an accessible select field.
-func (s *Select[T]) runAccessible(w io.Writer, r io.Reader) error {
+// RunAccessible runs an accessible select field.
+func (s *Select[T]) RunAccessible(w io.Writer, r io.Reader) error {
 	styles := s.activeStyles()
 	_, _ = fmt.Fprintln(w, styles.Title.
 		PaddingRight(1).
@@ -768,6 +768,9 @@ func (s *Select[T]) WithKeyMap(k *KeyMap) Field {
 }
 
 // WithAccessible sets the accessible mode of the select field.
+//
+// Deprecated: you may now call [Select.RunAccessible] directly to run the
+// field in accessible mode.
 func (s *Select[T]) WithAccessible(accessible bool) Field {
 	s.accessible = accessible
 	return s

--- a/field_text.go
+++ b/field_text.go
@@ -40,7 +40,7 @@ type Text struct {
 	validate func(string) error
 	err      error
 
-	accessible bool
+	accessible bool // Deprecated: use RunAccessible instead.
 	width      int
 
 	theme  *Theme
@@ -408,14 +408,14 @@ func (t *Text) View() string {
 
 // Run runs the text field.
 func (t *Text) Run() error {
-	if t.accessible {
-		return t.runAccessible(os.Stdout, os.Stdin)
+	if t.accessible { // TODO: remove in a future release.
+		return t.RunAccessible(os.Stdout, os.Stdin)
 	}
 	return Run(t)
 }
 
-// runAccessible runs an accessible text field.
-func (t *Text) runAccessible(w io.Writer, r io.Reader) error {
+// RunAccessible runs an accessible text field.
+func (t *Text) RunAccessible(w io.Writer, r io.Reader) error {
 	styles := t.activeStyles()
 	prompt := styles.Title.
 		PaddingRight(1).
@@ -457,6 +457,9 @@ func (t *Text) WithKeyMap(k *KeyMap) Field {
 }
 
 // WithAccessible sets the accessible mode of the text field.
+//
+// Deprecated: you may now call [Text.RunAccessible] directly to run the
+// field in accessible mode.
 func (t *Text) WithAccessible(accessible bool) Field {
 	t.accessible = accessible
 	return t

--- a/form.go
+++ b/form.go
@@ -151,7 +151,8 @@ type Field interface {
 	// Run runs the field individually.
 	Run() error
 
-	runAccessible(w io.Writer, r io.Reader) error
+	// RunAccessible runs the field in accessible mode with the given IO.
+	RunAccessible(w io.Writer, r io.Reader) error
 
 	// Skip returns whether this input should be skipped or not.
 	Skip() bool
@@ -167,6 +168,8 @@ type Field interface {
 	WithTheme(*Theme) Field
 
 	// WithAccessible sets whether the field should run in accessible mode.
+	//
+	// Deprecated: you may now call [Field.RunAccessible] directly to run the field in accessible mode.
 	WithAccessible(bool) Field
 
 	// WithKeyMap sets the keymap on a field.
@@ -707,7 +710,7 @@ func (f *Form) runAccessible(w io.Writer, r io.Reader) error {
 		group.selector.Range(func(_ int, field Field) bool {
 			field.Init()
 			field.Focus()
-			_ = field.WithAccessible(true).runAccessible(w, r)
+			_ = field.WithAccessible(true).RunAccessible(w, r)
 			_, _ = fmt.Fprintln(w)
 			return true
 		})

--- a/huh_test.go
+++ b/huh_test.go
@@ -1392,7 +1392,7 @@ func TestAccessibleFields(t *testing.T) {
 			}
 
 			var out bytes.Buffer
-			if err := field.runAccessible(
+			if err := field.RunAccessible(
 				&out,
 				strings.NewReader(test.Input),
 			); err != nil {
@@ -1413,12 +1413,12 @@ func TestInputPasswordAccessible(t *testing.T) {
 		var out bytes.Buffer
 		if err := NewInput().
 			EchoMode(EchoModeNone).
-			runAccessible(&out, bytes.NewReader(nil)); err == nil {
+			RunAccessible(&out, bytes.NewReader(nil)); err == nil {
 			t.Error("expected it to error")
 		}
 		if err := NewInput().
 			EchoMode(EchoModePassword).
-			runAccessible(&out, bytes.NewReader(nil)); err == nil {
+			RunAccessible(&out, bytes.NewReader(nil)); err == nil {
 			t.Error("expected it to error")
 		}
 	})
@@ -1438,7 +1438,7 @@ func TestInputPasswordAccessible(t *testing.T) {
 
 		errs := make(chan error, 1)
 		go func() {
-			errs <- input.runAccessible(&out, upty.Slave())
+			errs <- input.RunAccessible(&out, upty.Slave())
 		}()
 
 		upty.Master().Write([]byte("a password\n"))


### PR DESCRIPTION
This way we can remove make the public interface Field implementable by 3rd parties again.

closes #663
