### PR TITLE
docs(filepicker): correct godoc comment for DirAllowed function

### DIFF
--- a/field_filepicker.go
+++ b/field_filepicker.go
@@ -102,7 +102,7 @@ func (f *FilePicker) FileAllowed(v bool) *FilePicker {
 	return f
 }
 
-// DirAllowed sets whether to allow files to be selected.
+// DirAllowed sets whether to allow directories to be selected.
 func (f *FilePicker) DirAllowed(v bool) *FilePicker {
 	f.picker.DirAllowed = v
 	return f


### PR DESCRIPTION
### Describe your changes

The comment for the `DirAllowed` function incorrectly stated that it controlled whether files could be selected.

This function controls whether *directories* can be selected. This change corrects the comment to prevent confusion.

### Related issue/discussion: None

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
