### PR TITLE
feat:show dynamic '>' marker on focused option (Yes/No)

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -2,6 +2,7 @@ package huh
 
 import (
 	"cmp"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -11,6 +12,13 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/charmbracelet/huh/internal/accessibility"
+)
+
+// Use unicode block spaces for consistent spacing and calculate max width for alignment
+const (
+	markerSelected   = "▶ "  // Unicode triangle marker for selected option
+	markerUnselected = "  "  // Two unicode block spaces for unselected option
+	separator        = "   " // Three unicode block spaces for separation between options
 )
 
 // Confirm is a form confirm field.
@@ -263,25 +271,45 @@ func (c *Confirm) View() string {
 		sb.WriteString("\n")
 	}
 
+	// Calculate the maximum width needed for both options to ensure consistent layout
+	maxOptionWidth := max(len(c.affirmative), len(c.negative))
+
+	// Format options with consistent width padding
+	yesText := c.affirmative
+	noText := c.negative
+
+	// Pad options to ensure consistent width
+	yesTextPadded := fmt.Sprintf("%-*s", maxOptionWidth, yesText)
+	noTextPadded := fmt.Sprintf("%-*s", maxOptionWidth, noText)
+
+	var yesDisplay, noDisplay string
 	var negative string
 	var affirmative string
 	if c.negative != "" {
 		if c.accessor.Get() {
-			affirmative = styles.FocusedButton.Render("> " + c.affirmative)
-			negative = styles.BlurredButton.Render("  " + c.negative)
+			yesDisplay = markerSelected + yesTextPadded
+			noDisplay = markerUnselected + noTextPadded
 		} else {
-			affirmative = styles.BlurredButton.Render("  " + c.affirmative)
-			negative = styles.FocusedButton.Render("> " + c.negative)
+			yesDisplay = markerUnselected + yesTextPadded
+			noDisplay = markerSelected + noTextPadded
 		}
+
+		affirmative = styles.FocusedButton.Render(yesDisplay)
+		negative = styles.BlurredButton.Render(noDisplay)
+		if !c.accessor.Get() {
+			affirmative, negative = styles.BlurredButton.Render(yesDisplay), styles.FocusedButton.Render(noDisplay)
+		}
+
 		c.keymap.Reject.SetHelp("n", c.negative)
 	} else {
-		affirmative = styles.FocusedButton.Render("> " + c.affirmative)
+		yesDisplay = markerSelected + yesTextPadded
+		affirmative = styles.FocusedButton.Render(yesDisplay)
 		c.keymap.Reject.SetEnabled(false)
 	}
 
 	c.keymap.Accept.SetHelp("y", c.affirmative)
 
-	buttonsRow := lipgloss.JoinHorizontal(c.buttonAlignment, affirmative, negative)
+	buttonsRow := lipgloss.JoinHorizontal(lipgloss.Left, affirmative, separator, negative)
 
 	promptWidth := lipgloss.Width(sb.String())
 	buttonsWidth := lipgloss.Width(buttonsRow)


### PR DESCRIPTION
### Describe your changes
add dynamic selection marker for focused Yes/No option

Adds a visible “>” cursor to the focused confirm option (Yes/No), improving clarity when toggling with left/right or y/n. Visual-only change; no API changes.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

ISSUE: https://github.com/charmbracelet/huh/issues/684#issue-3311438064

before:

[Screencast from 2025-08-20 18-26-48.webm](https://github.com/user-attachments/assets/1354dfa1-fcb1-422b-85e0-3fa1a812d369)

after:

[Screencast from 2025-08-20 18-28-22.webm](https://github.com/user-attachments/assets/1cfc4082-f476-4612-9a69-bdcf12c0c1ed)

after 2nd commit:
[Screencast from 2025-08-21 12-44-20.webm](https://github.com/user-attachments/assets/8869db09-4fb7-4219-807a-1c910f2423a8)


