### PR TITLE
Fix editor destination

### DIFF
--- a/field_text.go
+++ b/field_text.go
@@ -276,7 +276,6 @@ func (t *Text) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		t.textarea, cmd = t.textarea.Update(msg)
 		cmds = append(cmds, cmd)
 		t.accessor.Set(t.textarea.Value())
-
 	case updateFieldMsg:
 		var cmds []tea.Cmd
 		if ok, hash := t.placeholder.shouldUpdate(); ok {


### PR DESCRIPTION
### Describe your changes

Changes made by an editor are published to all fields in the group. This PR ensures, that they are only applied if the editor was opened in the current text input.

### Related issue/discussion: #686 

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

