### PR TITLE
fix: Add missing id initialization in field_select constructor

### DIFF
--- a/field_select.go
+++ b/field_select.go
@@ -74,6 +74,7 @@ func NewSelect[T comparable]() *Select[T] {
 		validate:    func(T) error { return nil },
 		filtering:   false,
 		filter:      filter,
+		id:          nextID(),
 		options:     Eval[[]Option[T]]{cache: make(map[uint64][]Option[T])},
 		title:       Eval[string]{cache: make(map[uint64]string)},
 		description: Eval[string]{cache: make(map[uint64]string)},

--- a/huh_test.go
+++ b/huh_test.go
@@ -513,6 +513,106 @@ func TestSelect(t *testing.T) {
 	}
 }
 
+// doAllUpdates updates the form with the given command, then continues updating it with any resultant commands from the update until no more are returned.
+func doAllUpdates(f *Form, cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	var cmds []tea.Cmd
+	switch msg := cmd().(type) {
+	case tea.BatchMsg:
+		for _, subcommand := range msg {
+			doAllUpdates(f, subcommand)
+		}
+		return
+	default:
+		_, result := f.Update(msg)
+		cmds = append(cmds, result)
+	}
+	doAllUpdates(f, tea.Batch(cmds...))
+}
+
+func TestSelectDynamic(t *testing.T) {
+	trigger := "initial"
+
+	field1 := NewSelect[string]().
+		TitleFunc(func() string {
+			return "field1 title " + trigger
+		}, &trigger).
+		DescriptionFunc(func() string {
+			return "field1 desc " + trigger
+		}, &trigger).
+		OptionsFunc(func() []Option[string] {
+			return []Option[string]{NewOption("field1 opt "+trigger, "field1 opt "+trigger)}
+		}, &trigger)
+	field2 := NewSelect[string]().
+		TitleFunc(func() string {
+			return "field2 title " + trigger
+		}, &trigger).
+		DescriptionFunc(func() string {
+			return "field2 desc " + trigger
+		}, &trigger).
+		OptionsFunc(func() []Option[string] {
+			return []Option[string]{NewOption("field2 opt "+trigger, "field2 opt "+trigger)}
+		}, &trigger)
+	field1.WithHeight(5)
+	field2.WithHeight(5)
+	f := NewForm(NewGroup(field1, field2)).WithHeight(10)
+
+	doAllUpdates(f, f.Init())
+
+	view := ansi.Strip(f.View())
+
+	expectedStrings := []string{
+		"field1 title initial",
+		"field1 desc initial",
+		"field1 opt initial",
+		"field2 title initial",
+		"field2 desc initial",
+		"field2 opt initial",
+	}
+	for _, expected := range expectedStrings {
+		if !strings.Contains(view, expected) {
+			t.Log(pretty.Render(view))
+			t.Error("Expected view to contain " + expected)
+		}
+	}
+
+	if field1.GetValue() != "field1 opt initial" {
+		t.Errorf("Expected field1 value to be field1 opt initial but was %s", field1.GetValue())
+	}
+	if field2.GetValue() != "field2 opt initial" {
+		t.Errorf("Expected field2 value to be field2 opt initial but was %s", field2.GetValue())
+	}
+
+	trigger = "updated"
+	_, cmd := f.Update(nil)
+	doAllUpdates(f, cmd)
+	view = ansi.Strip(f.View())
+
+	expectedStrings = []string{
+		"field1 title updated",
+		"field1 desc updated",
+		"field1 opt updated",
+		"field2 title updated",
+		"field2 desc updated",
+		"field2 opt updated",
+	}
+	for _, expected := range expectedStrings {
+		if !strings.Contains(view, expected) {
+			t.Log(pretty.Render(view))
+			t.Error("Expected view to contain " + expected)
+		}
+	}
+
+	if field1.GetValue() != "field1 opt updated" {
+		t.Errorf("Expected field1 value to be field1 opt updated but was %s", field1.GetValue())
+	}
+	if field2.GetValue() != "field2 opt updated" {
+		t.Errorf("Expected field2 value to be field2 opt updated but was %s", field1.GetValue())
+	}
+}
+
 func TestMultiSelect(t *testing.T) {
 	field := NewMultiSelect[string]().
 		Options(NewOptions(


### PR DESCRIPTION
### Describe your changes
This fixes the field_select constructor to properly set the field's id.

### Related issue/discussion: https://github.com/charmbracelet/huh/issues/691

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
