### PR TITLE
Adjust Input to Enter in multiselect to match select

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -723,7 +723,7 @@ func (m *MultiSelect[T]) RunAccessible(w io.Writer, r io.Reader) error {
 	for {
 		m.printOptions(w)
 
-		prompt := fmt.Sprintf("Input a number between %d and %d: ", 0, len(m.options.val))
+		prompt := fmt.Sprintf("Enter a number between %d and %d: ", 0, len(m.options.val))
 		choice = accessibility.PromptInt(w, r, prompt, 0, len(m.options.val), nil)
 		if choice <= 0 {
 			m.updateValue()


### PR DESCRIPTION
## Description

Super silly PR but in https://github.com/charmbracelet/huh/pull/642#discussion_r2581112439 the `Select` field was adjusted from `Input` -> `Enter` so figured I'd bring multiselect over too to make it consistent.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
