### PR TITLE
fix(input): do not run validation on blur to allow backward navigation (Shift+Tab)

### DIFF
--- a/field_input.go
+++ b/field_input.go
@@ -254,7 +254,6 @@ func (i *Input) Blur() tea.Cmd {
 	i.focused = false
 	i.accessor.Set(i.textinput.Value())
 	i.textinput.Blur()
-	i.err = i.validate(i.accessor.Get())
 	return nil
 }
 


### PR DESCRIPTION
## Related issue: #720

## Summary
This PR removes unconditional validation from Input.Blur() so that validation only occurs when the user explicitly attempts to advance or submit a field (e.g. Enter).

This fixes an issue where navigating backward with Shift+Tab triggers validation and prevents users from returning to previous fields, which is inconsistent with expected TUI form behavior.

## Solution
Remove validation from Input.Blur() and rely on existing validation logic already present in the Update handler for Next and Submit key bindings.

## Checklist before requesting a review
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
