### PR TITLE
fix: prevent duplicate input events in form fields

### DIFF
--- a/group.go
+++ b/group.go
@@ -254,15 +254,18 @@ func (g *Group) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Update all the fields in the group.
 	g.selector.Range(func(i int, field Field) bool {
+		isSelectedField := g.selector.Index() == i
+		
 		switch msg := msg.(type) {
 		case tea.KeyMsg:
-			break
+			// KeyMsg should only go to the selected field
+			if isSelectedField {
+				m, cmd := field.Update(msg)
+				g.selector.Set(i, m.(Field))
+				cmds = append(cmds, cmd)
+			}
 		default:
-			m, cmd := field.Update(msg)
-			g.selector.Set(i, m.(Field))
-			cmds = append(cmds, cmd)
-		}
-		if g.selector.Index() == i {
+			// Non-key messages go to all fields
 			m, cmd := field.Update(msg)
 			g.selector.Set(i, m.(Field))
 			cmds = append(cmds, cmd)


### PR DESCRIPTION
- [ ✓ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ n/a ] I have created a discussion that was approved by a maintainer (for new features).


## Problem
Keyboard input events (including paste operations with Ctrl+V) are duplicated N times, where N is the number of fields in the form group. For example, pasting "test" into a 2-field form results in "testtest", and in a 3-field form results in "testtesttest".


## Steps to recreate
1. Copy a word or phrase from text into your clipboard (hihglight and ctrl-c)
2. cd huh/examples/burger && go run .
3. press <enter> 5 times to get to the text input field titled "What's your name?"
4. press ctrl-v  -- the contents from the clipboard are pasted twice

After the fix is applied, repeating the above 4 steps will result in the clipboard contents pasting only once.

## Root Cause
The `Update()` method in `group.go` was calling `field.Update(msg)` multiple times per field for every message:
1. In the default switch case for non-KeyMsg events  
6. For the selected field (with index check)
7. For updateFieldMsg

This meant `tea.KeyMsg` events were being sent to **all fields** instead of just the selected one.

## Solution
Added an `isSelectedField` check that only sends `tea.KeyMsg` events to the currently selected field, while other message types continue to be sent to all fields as before (preserving existing behavior for non-keyboard events).

## Testing
Tested with the `examples/burger` form - paste operations now work correctly without duplication.