### PR TITLE
fix: select cursor now moves instead of options scrolling

### DIFF
--- a/field_select.go
+++ b/field_select.go
@@ -540,7 +540,6 @@ func (s *Select[T]) updateViewportHeight() {
 	}
 
 	s.viewport.Height = max(minHeight, s.height-offset)
-	s.viewport.YOffset = s.selected
 }
 
 func (s *Select[T]) activeStyles() *FieldStyles {


### PR DESCRIPTION
Fixes #724

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ n/a ] I have created a discussion that was approved by a maintainer (for new features).

## Problem

In `Select` fields, the cursor remains fixed at the top of the viewport while options scroll up and down. This happens for both `Options()` and `OptionsFunc()`.

Users expect the cursor to move through the visible options, with the viewport only scrolling when the cursor reaches the edges.

## Steps to Reproduce

```go
huh.NewSelect[string]().
    Title("Select an item").
    Height(5).
    Options(
        huh.NewOption("Item 1", "1"),
        huh.NewOption("Item 2", "2"),
        huh.NewOption("Item 3", "3"),
        huh.NewOption("Item 4", "4"),
        huh.NewOption("Item 5", "5"),
        huh.NewOption("Item 6", "6"),
    )
```

* **Before** fix: Pressing down arrow causes "Item 1" to immediately disappear as options scroll, while cursor stays at the top.
* **After** fix: Cursor moves down through visible items. Viewport only scrolls when cursor reaches the bottom.

## Root Cause

In field_select.go:543, `updateViewportHeight()` was setting `s.viewport.YOffset = s.selected` on every update. Since `Update()` calls `updateViewportHeight()` on
every frame, the viewport offset was constantly being reset to match the selected index, creating the "scrolling options" effect.

## Solution

Removed line 543 (`s.viewport.YOffset = s.selected`). The viewport offset is already properly initialized in `selectOption()` and naturally managed by the existing
navigation logic in the `Update()` method.

## Testing

- [x] All existing tests pass 
  - [x] `go test -v ./...`
  - [x] `cd examples && go test -v ./...`
  - [x] `cd spinner && go test -v ./...`
- [x] Tested with `examples/dynamic/dynamic-country`
- [x] Verified both `Options()` and `OptionsFunc()` now behave correctly