### PR TITLE
feat(multiselect): wrap cursor at list boundaries

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -391,8 +391,13 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 				break
 			}
 
-			m.cursor = max(m.cursor-1, 0)
-			m.ensureCursorVisible()
+			m.cursor = m.cursor - 1
+			if m.cursor < 0 {
+				m.cursor = len(m.filteredOptions) - 1
+				m.viewport.GotoBottom()
+			} else {
+				m.ensureCursorVisible()
+			}
 		case key.Matches(msg, m.keymap.Down):
 			//nolint:godox
 			// FIXME: should use keys in keymap
@@ -400,8 +405,13 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 				break
 			}
 
-			m.cursor = min(m.cursor+1, len(m.filteredOptions)-1)
-			m.ensureCursorVisible()
+			m.cursor = m.cursor + 1
+			if m.cursor >= len(m.filteredOptions) {
+				m.cursor = 0
+				m.viewport.GotoTop()
+			} else {
+				m.ensureCursorVisible()
+			}
 		case key.Matches(msg, m.keymap.GotoTop):
 			if m.filtering {
 				break

--- a/huh_test.go
+++ b/huh_test.go
@@ -698,6 +698,52 @@ func TestMultiSelect(t *testing.T) {
 	}
 }
 
+func TestMultiSelectCursorWrap(t *testing.T) {
+	field := NewMultiSelect[string]().
+		Options(NewOptions("Foo", "Bar", "Baz")...).
+		Title("Which one?")
+	f := NewForm(NewGroup(field))
+	f.Update(f.Init())
+
+	// Cursor starts on first item.
+	if got, ok := field.Hovered(); !ok || got != "Foo" {
+		t.Fatalf("Expected cursor on Foo, got %q", got)
+	}
+
+	// Press Up at first item — should wrap to last item.
+	m := batchUpdate(f.Update(keypress('k')))
+	_ = viewModel(m)
+
+	if got, ok := field.Hovered(); !ok || got != "Baz" {
+		t.Errorf("Expected cursor to wrap to Baz, got %q", got)
+	}
+
+	// Press Down — should wrap back to first item.
+	m = batchUpdate(f.Update(keypress('j')))
+	_ = viewModel(m)
+
+	if got, ok := field.Hovered(); !ok || got != "Foo" {
+		t.Errorf("Expected cursor to wrap to Foo, got %q", got)
+	}
+
+	// Navigate to last item (Foo -> Bar -> Baz).
+	m = batchUpdate(f.Update(keypress('j')))
+	m = batchUpdate(f.Update(keypress('j')))
+	_ = viewModel(m)
+
+	if got, ok := field.Hovered(); !ok || got != "Baz" {
+		t.Fatalf("Expected cursor on Baz, got %q", got)
+	}
+
+	// Press Down at last item — should wrap to first item.
+	m = batchUpdate(f.Update(keypress('j')))
+	_ = viewModel(m)
+
+	if got, ok := field.Hovered(); !ok || got != "Foo" {
+		t.Errorf("Expected cursor to wrap to Foo, got %q", got)
+	}
+}
+
 func TestMultiSelectFiltering(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- Add cursor wrapping to `MultiSelect` so pressing up at the first item moves to the last, and pressing down at the last item moves to the first
- Matches the existing wrapping behavior in `Select`
- Adds test coverage for both wrap directions

Closes #356

## Test plan
- [x] `go test ./...` passes
- [x] `TestMultiSelectCursorWrap` covers up-wrap and down-wrap
- [x] Manual verification: run a multiselect prompt and confirm cursor wraps at both boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)