### PR TITLE
fix: remove extra space in error message causing misalignment with help text

### DIFF
--- a/theme.go
+++ b/theme.go
@@ -111,7 +111,7 @@ func ThemeBase(bool) *Styles {
 	t.Focused.Base = lipgloss.NewStyle().PaddingLeft(1).BorderStyle(lipgloss.ThickBorder()).BorderLeft(true)
 	t.Focused.Card = t.Focused.Base
 	t.Focused.ErrorIndicator = lipgloss.NewStyle().SetString(" *")
-	t.Focused.ErrorMessage = lipgloss.NewStyle().SetString(" *")
+	t.Focused.ErrorMessage = lipgloss.NewStyle().SetString("*")
 	t.Focused.SelectSelector = lipgloss.NewStyle().SetString("> ")
 	t.Focused.NextIndicator = lipgloss.NewStyle().MarginLeft(1).SetString("→")
 	t.Focused.PrevIndicator = lipgloss.NewStyle().MarginRight(1).SetString("←")


### PR DESCRIPTION
Fixes #723

`ErrorMessage` in `ThemeBase()` at theme.go:114 had `SetString(" *")` with a leading space, while `HelpMessage` uses `SetString("*")` without one. This caused the error footer to render 1 character to the right of the help text.

Changed `SetString(" *")` to `SetString("*")` so both messages start at the same column. `ErrorIndicator` on line 113 keeps its leading space since that's the separator between the field title and the asterisk.

The `Blurred` theme copies from `Focused` (line 128), and all other themes only override the foreground color on `ErrorMessage`, so this single change fixes it everywhere.