### PR TITLE
feat: add GroupIndex and GroupCount methods to Form

### DIFF
--- a/form.go
+++ b/form.go
@@ -505,6 +505,16 @@ func (f *Form) GetFocusedField() Field {
 	return f.selector.Selected().selector.Selected()
 }
 
+// GroupIndex returns the index of the currently active group.
+func (f *Form) GroupIndex() int {
+	return f.selector.Index()
+}
+
+// GroupCount returns the total number of groups in the form.
+func (f *Form) GroupCount() int {
+	return f.selector.Total()
+}
+
 // Init initializes the form.
 func (f *Form) Init() tea.Cmd {
 	var cmds []tea.Cmd


### PR DESCRIPTION
## Summary
- Add `GroupIndex()` method to return the index of the currently active group
- Add `GroupCount()` method to return the total number of groups in the form
- These methods enable users to track form progress and build UI indicators like "Step 2 of 5"

Closes #192

## Test plan
- [ ] Verify `GroupIndex()` returns 0 for the first group and increments as user progresses
- [ ] Verify `GroupCount()` returns the correct total number of groups
- [ ] Verify methods work correctly with hidden groups