### PR TITLE
fix: allow backtracking to previous group with validation errors

### DIFF
--- a/form.go
+++ b/form.go
@@ -603,10 +603,6 @@ func (f *Form) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return f, f.selector.Selected().Init()
 
 	case prevGroupMsg:
-		if len(group.Errors()) > 0 {
-			return f, nil
-		}
-
 		for i := f.selector.Index() - 1; i >= 0; i-- {
 			if !f.isGroupHidden(f.selector.Get(i)) {
 				f.selector.SetIndex(i)


### PR DESCRIPTION
## Summary
- Remove the error guard that prevented navigating to a previous group when the current group had validation errors
- Previously, pressing shift+tab on the first field of a group with errors would trap the user, making it impossible to go back and fix earlier inputs
- Forward navigation (`nextGroupMsg`) still correctly blocks when errors exist

Closes #540

## Test plan
- [ ] Verify pressing shift+tab on the first field navigates back even when current group has errors
- [ ] Verify forward navigation (enter/tab on last field) is still blocked when errors exist
- [ ] Verify backtracking skips hidden groups correctly