### PR TITLE
feat: show quit keybinding (ctrl+c) in help text

### DIFF
--- a/group.go
+++ b/group.go
@@ -394,7 +394,11 @@ func (g *Group) Footer() string {
 	var parts []string
 	errors := g.Errors()
 	if g.showHelp && len(errors) <= 0 {
-		parts = append(parts, g.help.ShortHelpView(g.selector.Selected().KeyBinds()))
+		binds := g.selector.Selected().KeyBinds()
+		if g.keymap != nil {
+			binds = append(binds, g.keymap.Quit)
+		}
+		parts = append(parts, g.help.ShortHelpView(binds))
 	}
 	if g.showErrors {
 		for _, err := range errors {

--- a/keymap.go
+++ b/keymap.go
@@ -106,7 +106,7 @@ type ConfirmKeyMap struct {
 // NewDefaultKeyMap returns a new default keymap.
 func NewDefaultKeyMap() *KeyMap {
 	return &KeyMap{
-		Quit: key.NewBinding(key.WithKeys("ctrl+c")),
+		Quit: key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit")),
 		Input: InputKeyMap{
 			AcceptSuggestion: key.NewBinding(key.WithKeys("ctrl+e"), key.WithHelp("ctrl+e", "complete")),
 			Prev:             key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "back")),


### PR DESCRIPTION
## Summary
- Add help text ("ctrl+c", "quit") to the Quit key binding in the default keymap
- Append the quit keybind to the group footer help display alongside field-specific keybinds
- Users can now discover the quit shortcut without consulting documentation

Closes #721

## Test plan
- [ ] Verify "ctrl+c quit" appears in the help bar at the bottom of the form
- [ ] Verify it appears alongside existing field keybinds (e.g., "enter next", "shift+tab back")
- [ ] Verify custom keymaps that override Quit still display correctly