### PR TITLE
feat: allow adding custom keybindings to help display

### DIFF
--- a/form.go
+++ b/form.go
@@ -249,6 +249,19 @@ func (f *Form) WithShowHelp(v bool) *Form {
 	return f
 }
 
+// WithHelpBinds appends additional key bindings to the help display of all
+// groups in the form.
+//
+// This allows displaying custom key bindings in the help bar alongside the
+// field-specific bindings.
+func (f *Form) WithHelpBinds(binds ...key.Binding) *Form {
+	f.selector.Range(func(_ int, group *Group) bool {
+		group.WithHelpBinds(binds...)
+		return true
+	})
+	return f
+}
+
 // WithShowErrors sets whether or not the form should show errors.
 //
 // This allows the form groups and fields to show errors when the Validate

--- a/group.go
+++ b/group.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2/internal/selector"
@@ -28,8 +29,9 @@ type Group struct {
 	viewport viewport.Model
 
 	// help
-	showHelp bool
-	help     help.Model
+	showHelp  bool
+	help      help.Model
+	helpBinds []key.Binding
 
 	// errors
 	showErrors bool
@@ -82,6 +84,15 @@ func (g *Group) Description(description string) *Group {
 // WithShowHelp sets whether or not the group's help should be shown.
 func (g *Group) WithShowHelp(show bool) *Group {
 	g.showHelp = show
+	return g
+}
+
+// WithHelpBinds appends additional key bindings to the group's help display.
+//
+// This allows displaying custom key bindings in the help bar alongside the
+// field-specific bindings.
+func (g *Group) WithHelpBinds(binds ...key.Binding) *Group {
+	g.helpBinds = append(g.helpBinds, binds...)
 	return g
 }
 
@@ -394,7 +405,9 @@ func (g *Group) Footer() string {
 	var parts []string
 	errors := g.Errors()
 	if g.showHelp && len(errors) <= 0 {
-		parts = append(parts, g.help.ShortHelpView(g.selector.Selected().KeyBinds()))
+		binds := g.selector.Selected().KeyBinds()
+		binds = append(binds, g.helpBinds...)
+		parts = append(parts, g.help.ShortHelpView(binds))
 	}
 	if g.showErrors {
 		for _, err := range errors {


### PR DESCRIPTION
## Summary
- Add `WithHelpBinds(...key.Binding)` method on `Group` to append custom key bindings to a specific group's help bar
- Add `WithHelpBinds(...key.Binding)` method on `Form` to append custom key bindings to all groups' help bars
- Custom bindings are displayed alongside field-specific keybinds in the footer

Closes #722

## Test plan
- [ ] Verify custom bindings appear in the help bar when added via `Group.WithHelpBinds()`
- [ ] Verify custom bindings appear on all groups when added via `Form.WithHelpBinds()`
- [ ] Verify existing field-specific keybinds still display correctly
- [ ] Verify disabled custom bindings are not shown