### PR TITLE
fix: improve visual distinction between confirm button states

### DIFF
--- a/theme.go
+++ b/theme.go
@@ -118,8 +118,8 @@ func ThemeBase(bool) *Styles {
 	t.Focused.MultiSelectSelector = lipgloss.NewStyle().SetString("> ")
 	t.Focused.SelectedPrefix = lipgloss.NewStyle().SetString("[•] ")
 	t.Focused.UnselectedPrefix = lipgloss.NewStyle().SetString("[ ] ")
-	t.Focused.FocusedButton = button.Foreground(lipgloss.Color("0")).Background(lipgloss.Color("7"))
-	t.Focused.BlurredButton = button.Foreground(lipgloss.Color("7")).Background(lipgloss.Color("0"))
+	t.Focused.FocusedButton = button.Foreground(lipgloss.Color("0")).Background(lipgloss.Color("7")).Bold(true).Underline(true)
+	t.Focused.BlurredButton = button.Foreground(lipgloss.Color("8")).Background(lipgloss.Color("0")).Faint(true)
 	t.Focused.TextInput.Placeholder = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 
 	t.Help = help.New().Styles


### PR DESCRIPTION
## Summary
- Make the selected (focused) confirm button **bold** and **underlined** in the base theme
- Make the unselected (blurred) confirm button **faint** with dimmer foreground color
- All themes inheriting from ThemeBase benefit from this improved contrast
- Addresses the issue where it was difficult to tell which confirm option was currently selected

Closes #630

## Test plan
- [ ] Verify the selected button is visually distinct (bold + underlined) in default theme
- [ ] Verify the unselected button appears dimmer/faint
- [ ] Verify Charm, Dracula, Catppuccin, Base16, and Gruvbox themes still look correct
- [ ] Verify button distinction works in both light and dark terminal backgrounds