### PR TITLE
fix(input): avoid a panic on small or buggy terminal

### DIFF
--- a/field_input.go
+++ b/field_input.go
@@ -485,9 +485,9 @@ func (i *Input) WithWidth(width int) Field {
 	promptWidth := lipgloss.Width(i.textinput.Styles().Focused.Prompt.Render(i.textinput.Prompt))
 	titleWidth := lipgloss.Width(styles.Title.Render(i.title.val))
 	descriptionWidth := lipgloss.Width(styles.Description.Render(i.description.val))
-	i.textinput.SetWidth(width - frameSize - promptWidth - 1)
+	i.textinput.SetWidth(max(width-frameSize-promptWidth-1, 0))
 	if i.inline {
-		i.textinput.SetWidth(i.textinput.Width() - titleWidth - descriptionWidth)
+		i.textinput.SetWidth(max(i.textinput.Width()-titleWidth-descriptionWidth, 0))
 	}
 	return i
 }


### PR DESCRIPTION
I ran the huh examples in the terminal of jetbrains goland, which for some reason seems to give inacurate window size information, leading to input computing a negative size and crashing. This fix the issue, and the rendering works in that same terminal.

Here is the panic:

```
/home/michael/.cache/JetBrains/GoLand2026.1/tmp/GoLand/___go_build_examples_burger
Caught panic:

runtime error: makeslice: len out of range

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
        /home/michael/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.linux-amd64/src/runtime/debug/stack.go:26 +0x5e
charm.land/bubbletea/v2.(*Program).recoverFromPanic(0x349345d04780, {0x6224e0, 0x67c090})
        /home/michael/go/pkg/mod/charm.land/bubbletea/v2@v2.0.6/tea.go:1279 +0x151
charm.land/bubbletea/v2.(*Program).Run.func2()
        /home/michael/go/pkg/mod/charm.land/bubbletea/v2@v2.0.6/tea.go:1030 +0x10c
panic({0x6224e0?, 0x67c090?})
        /home/michael/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.linux-amd64/src/runtime/panic.go:860 +0x13a
charm.land/bubbles/v2/textinput.Model.placeholderView({{0x0, 0x0}, {0x6689ca, 0x2}, {0x66dd47, 0x11}, 0x0, 0x2a, 0x1, {{0x400, ...}, ...}, ...})
        /home/michael/go/pkg/mod/charm.land/bubbles/v2@v2.1.0/textinput/textinput.go:748 +0x15c
charm.land/bubbles/v2/textinput.Model.View({{0x0, 0x0}, {0x6689ca, 0x2}, {0x66dd47, 0x11}, 0x0, 0x2a, 0x1, {{0x400, ...}, ...}, ...})
        /home/michael/go/pkg/mod/charm.land/bubbles/v2@v2.1.0/textinput/textinput.go:687 +0x53
charm.land/huh/v2.(*Input).View(0x349345f92008)
        /home/michael/dev/huh/field_input.go:412 +0x997
charm.land/huh/v2.(*Group).getContent.func1(...)
        /home/michael/dev/huh/group.go:315
charm.land/huh/v2/internal/selector.(*Selector[...]).Range(...)
        /home/michael/dev/huh/internal/selector/selector.go:83
charm.land/huh/v2.(*Group).getContent(0x349345da4008)
        /home/michael/dev/huh/group.go:314 +0x368
charm.land/huh/v2.(*Group).Content(...)
        /home/michael/dev/huh/group.go:388
charm.land/huh/v2.(*Group).rawHeight(0x349345da4008)
        /home/michael/dev/huh/group.go:362 +0x18
charm.land/huh/v2.(*Form).Update.func2(...)
        /home/michael/dev/huh/form.go:552
charm.land/huh/v2/internal/selector.(*Selector[...]).Range(...)
        /home/michael/dev/huh/internal/selector/selector.go:83
charm.land/huh/v2.(*Form).Update(0x349345e7c0c0, {0x637460, 0x349345c47f50})
        /home/michael/dev/huh/form.go:551 +0x7d9
charm.land/huh/v2/internal/compat.ViewModel.Update(...)
        /home/michael/dev/huh/internal/compat/model.go:24
charm.land/bubbletea/v2.(*Program).eventLoop(0x349345d04780, {0x67de00?, 0x349345c44210?}, 0x349345cd21c0)
        /home/michael/go/pkg/mod/charm.land/bubbletea/v2@v2.0.6/tea.go:872 +0xe46
charm.land/bubbletea/v2.(*Program).Run(0x349345d04780)
        /home/michael/go/pkg/mod/charm.land/bubbletea/v2@v2.0.6/tea.go:1144 +0xab0
charm.land/huh/v2.(*Form).run(0x349345e7c0c0, {0x67e278?, 0x925080?})
        /home/michael/dev/huh/form.go:707 +0x20a
charm.land/huh/v2.(*Form).RunWithContext(0x349345cbafa0?, {0x67e278?, 0x925080?})
        /home/michael/dev/huh/form.go:683 +0xd0
charm.land/huh/v2.(*Form).Run(...)
        /home/michael/dev/huh/form.go:664
main.main()
        /home/michael/dev/huh/examples/burger/main.go:154 +0x13a8

panic: interface conversion: tea.Model is nil, not compat.ViewModel

goroutine 1 [running]:
charm.land/huh/v2.(*Form).run(0x349345e7c0c0, {0x67e278?, 0x925080?})
        /home/michael/dev/huh/form.go:708 +0x498
charm.land/huh/v2.(*Form).RunWithContext(0x349345cbafa0?, {0x67e278?, 0x925080?})
        /home/michael/dev/huh/form.go:683 +0xd0
charm.land/huh/v2.(*Form).Run(...)
        /home/michael/dev/huh/form.go:664
main.main()
        /home/michael/dev/huh/examples/burger/main.go:154 +0x13a8

Process finished with the exit code 2
```

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
