### PR TITLE
docs(readme): fix spinner examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ fmt.Println("Order up!")
 </tr>
 </table>
 
-For more on Spinners see the [spinner examples](./spinner/examples) and
+For more on Spinners see the [spinner examples](./examples/spinner) and
 [the spinner docs](https://pkg.go.dev/charm.land/huh/v2/spinner).
 
 ## What about Bubble Tea?


### PR DESCRIPTION
I noticed the link was broken when reviewing the README.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
