### PR TITLE
feat(select): add scroll indicators showing when there is hidden items

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -590,14 +590,21 @@ func (m *MultiSelect[T]) descriptionView() string {
 	return m.activeStyles().Description.Render(wrap(m.description.val, maxWidth))
 }
 
-func (m *MultiSelect[T]) renderOption(option Option[T], cursor, selected bool) string {
+func (m *MultiSelect[T]) renderOption(option Option[T], cursor, selected, showUp, showDown bool) string {
 	styles := m.activeStyles()
 	var parts []string
-	if cursor {
+
+	switch {
+	case showUp:
+		parts = append(parts, styles.ScrollUpIndicator.String())
+	case showDown:
+		parts = append(parts, styles.ScrollDownIndicator.String())
+	case cursor:
 		parts = append(parts, styles.MultiSelectSelector.String())
-	} else {
+	default:
 		parts = append(parts, strings.Repeat(" ", lipgloss.Width(styles.MultiSelectSelector.String())))
 	}
+
 	if selected {
 		parts = append(parts, styles.SelectedPrefix.String())
 		parts = append(parts, styles.SelectedOption.Render(option.Key))
@@ -608,26 +615,45 @@ func (m *MultiSelect[T]) renderOption(option Option[T], cursor, selected bool) s
 	return lipgloss.JoinHorizontal(lipgloss.Left, parts...)
 }
 
-// cursorLineOffset computes the line offset and height (in lines) for the
-// current cursor position without rendering the full options string.
-func (m *MultiSelect[T]) cursorLineOffset() (offset int, height int) {
-	for i, option := range m.filteredOptions {
-		line := m.renderOption(option, m.cursor == i, m.filteredOptions[i].selected)
-		h := lipgloss.Height(line)
-		if i < m.cursor {
-			offset += h
+func (m *MultiSelect[T]) ensureCursorVisible() {
+	n := len(m.filteredOptions)
+	if n == 0 {
+		return
+	}
+
+	// collect prev, cursor, and next item offsets.
+	var prevOffset, prevHeight int
+	var cursorOffset, cursorHeight int
+	var nextOffset, nextHeight int
+	cum := 0
+	for i := 0; i < n && i <= m.cursor+1; i++ {
+		h := lipgloss.Height(m.renderOption(m.filteredOptions[i], m.cursor == i, m.filteredOptions[i].selected, false, false))
+		switch i {
+		case m.cursor - 1:
+			prevOffset = cum
+			prevHeight = h
+		case m.cursor:
+			cursorOffset = cum
+			cursorHeight = h
+		case m.cursor + 1:
+			nextOffset = cum
+			nextHeight = h
 		}
-		if i == m.cursor {
-			height = h
-			return offset, height
+		cum += h
+	}
+
+	// When the viewport is tall enough for lookahead, ensure the adjacent items
+	// are visible so the scroll indicators remain on screen. The cursor call is
+	// last so it always wins if the viewport is too small to fit everything.
+	if m.viewport.Height() >= 3 {
+		if m.cursor > 0 {
+			ensureVisible(&m.viewport, prevOffset, prevHeight)
+		}
+		if m.cursor+1 < n {
+			ensureVisible(&m.viewport, nextOffset, nextHeight)
 		}
 	}
-	return offset, height
-}
-
-func (m *MultiSelect[T]) ensureCursorVisible() {
-	offset, height := m.cursorLineOffset()
-	ensureVisible(&m.viewport, offset, height)
+	ensureVisible(&m.viewport, cursorOffset, cursorHeight)
 }
 
 func (m *MultiSelect[T]) optionsView() (string, int, int) {
@@ -639,23 +665,36 @@ func (m *MultiSelect[T]) optionsView() (string, int, int) {
 		return sb.String(), -1, 1
 	}
 
-	var cursorOffset int
-	var cursorHeight int
+	n := len(m.filteredOptions)
+
+	// Pass 1: compute per-item heights and cumulative line offsets.
+	heights := make([]int, n)
+	offsets := make([]int, n)
+	cum := 0
 	for i, option := range m.filteredOptions {
-		cursor := m.cursor == i
-		line := m.renderOption(option, cursor, m.filteredOptions[i].selected)
-		if i < m.cursor {
-			cursorOffset += lipgloss.Height(line)
-		}
-		if cursor {
-			cursorHeight = lipgloss.Height(line)
-		}
+		h := lipgloss.Height(m.renderOption(option, m.cursor == i, option.selected, false, false))
+		heights[i] = h
+		offsets[i] = cum
+		cum += h
+	}
+
+	var cursorOffset, cursorHeight int
+	if m.cursor < n {
+		cursorOffset = offsets[m.cursor]
+		cursorHeight = heights[m.cursor]
+	}
+
+	// Determine scroll indicator positions.
+	firstVisible, lastVisible := scrollIndicators(offsets, heights, cum, m.cursor, m.viewport.YOffset(), m.viewport.Height())
+
+	// Pass 2: render options with indicators.
+	for i, option := range m.filteredOptions {
+		line := m.renderOption(option, m.cursor == i, option.selected, i == firstVisible, i == lastVisible)
 		sb.WriteString(line)
 		if i < len(m.options.val)-1 {
 			sb.WriteString("\n")
 		}
 	}
-
 	for i := len(m.filteredOptions); i < len(m.options.val)-1; i++ {
 		sb.WriteString("\n")
 	}

--- a/field_select.go
+++ b/field_select.go
@@ -583,10 +583,7 @@ func (s *Select[T]) descriptionView() string {
 }
 
 func (s *Select[T]) optionsView() (string, int, int) {
-	var (
-		styles = s.activeStyles()
-		sb     strings.Builder
-	)
+	var sb strings.Builder
 
 	if s.options.loading && time.Since(s.options.loadingStart) > spinnerShowThreshold {
 		s.spinner.Style = s.activeStyles().MultiSelectSelector.UnsetString()
@@ -595,6 +592,7 @@ func (s *Select[T]) optionsView() (string, int, int) {
 	}
 
 	if s.inline {
+		styles := s.activeStyles()
 		option := styles.TextInput.Placeholder.Render("No matches")
 		if len(s.filteredOptions) > 0 {
 			option = styles.SelectedOption.Render(s.filteredOptions[s.selected].Key)
@@ -610,24 +608,36 @@ func (s *Select[T]) optionsView() (string, int, int) {
 			-1, 1
 	}
 
-	var cursorOffset int
-	var cursorHeight int
-	for i, option := range s.filteredOptions {
-		selected := s.selected == i
-		line := s.renderOption(option, selected)
-		if i < s.selected {
-			cursorOffset += lipgloss.Height(line)
-		}
-		if selected {
-			cursorHeight = lipgloss.Height(line)
-		}
+	n := len(s.filteredOptions)
 
+	// Pass 1: compute per-item heights and cumulative line offsets.
+	heights := make([]int, n)
+	offsets := make([]int, n)
+	cum := 0
+	for i, option := range s.filteredOptions {
+		h := lipgloss.Height(s.renderOption(option, s.selected == i, false, false))
+		heights[i] = h
+		offsets[i] = cum
+		cum += h
+	}
+
+	var cursorOffset, cursorHeight int
+	if s.selected < n {
+		cursorOffset = offsets[s.selected]
+		cursorHeight = heights[s.selected]
+	}
+
+	// Determine scroll indicator positions.
+	firstVisible, lastVisible := scrollIndicators(offsets, heights, cum, s.selected, s.viewport.YOffset(), s.viewport.Height())
+
+	// Pass 2: render options with indicators.
+	for i, option := range s.filteredOptions {
+		line := s.renderOption(option, s.selected == i, i == firstVisible, i == lastVisible)
 		sb.WriteString(line)
 		if i < len(s.options.val)-1 {
 			sb.WriteString("\n")
 		}
 	}
-
 	for i := len(s.filteredOptions); i < len(s.options.val)-1; i++ {
 		sb.WriteString("\n")
 	}
@@ -635,21 +645,52 @@ func (s *Select[T]) optionsView() (string, int, int) {
 	return sb.String(), cursorOffset, cursorHeight
 }
 
-// cursorLineOffset computes the line offset and height (in lines) for the
-// currently selected option without rendering the full options string.
-func (s *Select[T]) cursorLineOffset() (offset int, height int) {
-	for i, option := range s.filteredOptions {
-		line := s.renderOption(option, s.selected == i)
-		h := lipgloss.Height(line)
-		if i < s.selected {
-			offset += h
+// scrollIndicators returns the indices of the first and last visible options
+// that should carry a scroll indicator (↑ / ↓), or -1 when none is needed.
+//
+// offsets and heights are parallel slices: offsets[i] is the starting row of
+// option i within the full (unclipped) content, heights[i] is how many rows it
+// occupies. totalHeight is the sum of all heights. viewTop and viewHeight
+// describe the visible window (viewport.YOffset() and viewport.Height()).
+// cursor is the index of the currently selected option.
+//
+// ↑ is placed on the first visible option when content is hidden above.
+// ↓ is placed on the last visible option when content is hidden below.
+// Either indicator is suppressed when it would land on the cursor line, and
+// both are suppressed when fewer than 3 options are visible (too few to
+// maintain the lookahead-scroll invariant that keeps an indicator visible
+// while the cursor is one step away from the edge).
+func scrollIndicators(offsets, heights []int, totalHeight, cursor, viewTop, viewHeight int) (first, last int) {
+	first, last = -1, -1
+	if viewHeight == 0 {
+		return
+	}
+	viewBottom := viewTop + viewHeight - 1
+
+	var visibleCount int
+	for i := range offsets {
+		if offsets[i] > viewBottom {
+			break
 		}
-		if i == s.selected {
-			height = h
-			return offset, height
+		if offsets[i]+heights[i]-1 >= viewTop {
+			if first < 0 {
+				first = i
+			}
+			last = i
+			visibleCount++
 		}
 	}
-	return offset, height
+
+	if visibleCount < 3 {
+		return -1, -1
+	}
+	if viewTop == 0 || first == cursor {
+		first = -1
+	}
+	if totalHeight <= viewTop+viewHeight || last == cursor || last == first {
+		last = -1
+	}
+	return
 }
 
 // ensureVisible scrolls a viewport the minimum amount so that the region
@@ -668,11 +709,44 @@ func ensureVisible(vp *viewport.Model, offset, height int) {
 }
 
 func (s *Select[T]) ensureCursorVisible() {
-	offset, height := s.cursorLineOffset()
-	ensureVisible(&s.viewport, offset, height)
+	n := len(s.filteredOptions)
+	if n == 0 {
+		return
+	}
+
+	// Single pass: collect prev, cursor, and next item offsets.
+	var prevOffset, prevHeight int
+	var cursorOffset, cursorHeight int
+	var nextOffset, nextHeight int
+	cum := 0
+	for i := 0; i < n && i <= s.selected+1; i++ {
+		h := lipgloss.Height(s.renderOption(s.filteredOptions[i], i == s.selected, false, false))
+		switch i {
+		case s.selected - 1:
+			prevOffset, prevHeight = cum, h
+		case s.selected:
+			cursorOffset, cursorHeight = cum, h
+		case s.selected + 1:
+			nextOffset, nextHeight = cum, h
+		}
+		cum += h
+	}
+
+	// When the viewport is tall enough for lookahead, ensure the adjacent items
+	// are visible so the scroll indicators remain on screen. The cursor call is
+	// last so it always wins if the viewport is too small to fit everything.
+	if s.viewport.Height() >= 3 {
+		if s.selected > 0 {
+			ensureVisible(&s.viewport, prevOffset, prevHeight)
+		}
+		if s.selected+1 < n {
+			ensureVisible(&s.viewport, nextOffset, nextHeight)
+		}
+	}
+	ensureVisible(&s.viewport, cursorOffset, cursorHeight)
 }
 
-func (s *Select[T]) renderOption(option Option[T], selected bool) string {
+func (s *Select[T]) renderOption(option Option[T], selected, showUp, showDown bool) string {
 	var (
 		styles   = s.activeStyles()
 		cursor   = styles.SelectSelector.String()
@@ -682,18 +756,22 @@ func (s *Select[T]) renderOption(option Option[T], selected bool) string {
 
 	key := wrap(option.Key, maxWidth)
 
-	if selected {
-		return lipgloss.JoinHorizontal(
-			lipgloss.Left,
-			cursor,
-			styles.SelectedOption.Render(key),
-		)
+	var cursorCol string
+	switch {
+	case showUp:
+		cursorCol = styles.ScrollUpIndicator.String()
+	case showDown:
+		cursorCol = styles.ScrollDownIndicator.String()
+	case selected:
+		cursorCol = cursor
+	default:
+		cursorCol = strings.Repeat(" ", lipgloss.Width(cursor))
 	}
-	return lipgloss.JoinHorizontal(
-		lipgloss.Left,
-		strings.Repeat(" ", cursorW),
-		styles.UnselectedOption.Render(key),
-	)
+
+	if selected {
+		return lipgloss.JoinHorizontal(lipgloss.Left, cursorCol, styles.SelectedOption.Render(key))
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Left, cursorCol, styles.UnselectedOption.Render(key))
 }
 
 // View renders the select field.

--- a/huh_test.go
+++ b/huh_test.go
@@ -1575,6 +1575,141 @@ func TestInputPasswordAccessible(t *testing.T) {
 	})
 }
 
+func TestScrollIndicators(t *testing.T) {
+	offsets := []int{0, 1, 2, 3, 4, 5, 6, 7}
+	heights := []int{1, 1, 1, 1, 1, 1, 1, 1}
+	const total = 8
+
+	for _, tc := range []struct {
+		name                        string
+		cursor, viewTop, viewHeight int
+		wantFirst, wantLast         int
+	}{
+		{"all fit", 0, 0, 8, -1, -1},
+		{"down indicator at top", 0, 0, 5, -1, 4},
+		{"up indicator at bottom", 7, 3, 5, 3, -1},
+		{"both in middle", 3, 1, 5, 1, 5},
+		{"cursor suppresses up", 1, 1, 5, -1, 5},
+		{"cursor suppresses down", 5, 1, 5, 1, -1},
+		{"too few visible", 0, 0, 2, -1, -1},
+		{"exactly 3 visible", 1, 0, 3, -1, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			first, last := scrollIndicators(offsets, heights, total, tc.cursor, tc.viewTop, tc.viewHeight)
+			if first != tc.wantFirst || last != tc.wantLast {
+				t.Errorf("got (%d, %d), want (%d, %d)", first, last, tc.wantFirst, tc.wantLast)
+			}
+		})
+	}
+}
+
+func TestScrollIndicatorsView(t *testing.T) {
+	// 8 single-line options; height 6 → viewport 5 (minus 1 title line).
+	opts := NewOptions("Opt1", "Opt2", "Opt3", "Opt4", "Opt5", "Opt6", "Opt7", "Opt8")
+
+	type fieldCase struct {
+		makeField func(height int) Field
+		upPat     string
+		downPat   string
+	}
+	for name, tc := range map[string]fieldCase{
+		"select": {
+			makeField: func(h int) Field {
+				return NewSelect[string]().Title("Pick").Options(opts...).Height(h)
+			},
+			upPat:   "↑ Opt",
+			downPat: "↓ Opt",
+		},
+		"multiselect": {
+			makeField: func(h int) Field {
+				return NewMultiSelect[string]().Title("Pick").Options(opts...).Height(h)
+			},
+			upPat:   "↑ •",
+			downPat: "↓ •",
+		},
+	} {
+		makeField, upPat, downPat := tc.makeField, tc.upPat, tc.downPat
+		t.Run(name, func(t *testing.T) {
+			t.Run("down indicator at top", func(t *testing.T) {
+				f := NewForm(NewGroup(makeField(6)))
+				f.Update(f.Init())
+				view := viewModel(f)
+				if strings.Contains(view, upPat) {
+					t.Log(pretty.Render(view))
+					t.Error("expected no ↑ at top of list")
+				}
+				if !strings.Contains(view, downPat) {
+					t.Log(pretty.Render(view))
+					t.Error("expected ↓ when items extend below viewport")
+				}
+			})
+
+			t.Run("both indicators in middle", func(t *testing.T) {
+				f := NewForm(NewGroup(makeField(6)))
+				f.Update(f.Init())
+				// 4 presses: cursor reaches the lookahead threshold and the
+				// viewport scrolls, revealing hidden items above.
+				m := batchUpdate(f.Update(keypress('j')))
+				for range 3 {
+					m = batchUpdate(m.Update(keypress('j')))
+				}
+				view := viewModel(m)
+				if !strings.Contains(view, upPat) {
+					t.Log(pretty.Render(view))
+					t.Error("expected ↑ when items extend above viewport")
+				}
+				if !strings.Contains(view, downPat) {
+					t.Log(pretty.Render(view))
+					t.Error("expected ↓ when items extend below viewport")
+				}
+				for _, line := range strings.Split(view, "\n") {
+					if strings.Contains(line, "> ") && (strings.Contains(line, upPat) || strings.Contains(line, downPat)) {
+						t.Log(pretty.Render(view))
+						t.Errorf("scroll indicator must not appear on cursor line: %q", line)
+					}
+				}
+			})
+
+			t.Run("no down indicator at last item", func(t *testing.T) {
+				f := NewForm(NewGroup(makeField(6)))
+				f.Update(f.Init())
+				m := batchUpdate(f.Update(keypress('G')))
+				view := viewModel(m)
+				if strings.Contains(view, downPat) {
+					t.Log(pretty.Render(view))
+					t.Error("expected no ↓ at last item")
+				}
+			})
+
+			t.Run("no indicators when all fit", func(t *testing.T) {
+				// height 10 → viewport 9; all 8 options are visible.
+				f := NewForm(NewGroup(makeField(10)))
+				f.Update(f.Init())
+				view := viewModel(f)
+				if strings.Contains(view, upPat) || strings.Contains(view, downPat) {
+					t.Log(pretty.Render(view))
+					t.Error("expected no indicators when all options fit in the viewport")
+				}
+			})
+
+			t.Run("no indicators with small viewport", func(t *testing.T) {
+				// height 3 → viewport 2; below the 3-item threshold.
+				f := NewForm(NewGroup(makeField(3)))
+				f.Update(f.Init())
+				m := batchUpdate(f.Update(keypress('j')))
+				for range 3 {
+					m = batchUpdate(m.Update(keypress('j')))
+				}
+				view := viewModel(m)
+				if strings.Contains(view, upPat) || strings.Contains(view, downPat) {
+					t.Log(pretty.Render(view))
+					t.Error("expected no indicators when viewport is too small")
+				}
+			})
+		})
+	}
+}
+
 func requireEqual[T comparable](tb testing.TB, a, b T) {
 	tb.Helper()
 	if a != b {

--- a/theme.go
+++ b/theme.go
@@ -51,10 +51,12 @@ type FieldStyles struct {
 	ErrorMessage   lipgloss.Style
 
 	// Select styles.
-	SelectSelector lipgloss.Style // Selection indicator
-	Option         lipgloss.Style // Select options
-	NextIndicator  lipgloss.Style
-	PrevIndicator  lipgloss.Style
+	SelectSelector      lipgloss.Style // Selection indicator
+	Option              lipgloss.Style // Select options
+	NextIndicator       lipgloss.Style
+	PrevIndicator       lipgloss.Style
+	ScrollUpIndicator   lipgloss.Style
+	ScrollDownIndicator lipgloss.Style
 
 	// FilePicker styles.
 	Directory lipgloss.Style
@@ -115,6 +117,8 @@ func ThemeBase(bool) *Styles {
 	t.Focused.SelectSelector = lipgloss.NewStyle().SetString("> ")
 	t.Focused.NextIndicator = lipgloss.NewStyle().MarginLeft(1).SetString("→")
 	t.Focused.PrevIndicator = lipgloss.NewStyle().MarginRight(1).SetString("←")
+	t.Focused.ScrollUpIndicator = lipgloss.NewStyle().SetString("↑ ")
+	t.Focused.ScrollDownIndicator = lipgloss.NewStyle().SetString("↓ ")
 	t.Focused.MultiSelectSelector = lipgloss.NewStyle().SetString("> ")
 	t.Focused.SelectedPrefix = lipgloss.NewStyle().SetString("[•] ")
 	t.Focused.UnselectedPrefix = lipgloss.NewStyle().SetString("[ ] ")
@@ -131,6 +135,8 @@ func ThemeBase(bool) *Styles {
 	t.Blurred.MultiSelectSelector = lipgloss.NewStyle().SetString("  ")
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
+	t.Blurred.ScrollUpIndicator = lipgloss.NewStyle().SetString("  ")
+	t.Blurred.ScrollDownIndicator = lipgloss.NewStyle().SetString("  ")
 
 	return &t
 }
@@ -160,6 +166,8 @@ func ThemeCharm(isDark bool) *Styles {
 	t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(fuchsia)
 	t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(fuchsia)
 	t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(fuchsia)
+	t.Focused.ScrollUpIndicator = t.Focused.ScrollUpIndicator.Foreground(fuchsia)
+	t.Focused.ScrollDownIndicator = t.Focused.ScrollDownIndicator.Foreground(fuchsia)
 	t.Focused.Option = t.Focused.Option.Foreground(normalFg)
 	t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(fuchsia)
 	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(green)
@@ -179,6 +187,8 @@ func ThemeCharm(isDark bool) *Styles {
 	t.Blurred.Card = t.Blurred.Base
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
+	t.Blurred.ScrollUpIndicator = lipgloss.NewStyle().SetString("  ")
+	t.Blurred.ScrollDownIndicator = lipgloss.NewStyle().SetString("  ")
 
 	t.Group.Title = t.Focused.Title
 	t.Group.Description = t.Focused.Description
@@ -212,6 +222,8 @@ func ThemeDracula(isDark bool) *Styles {
 	t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(yellow)
 	t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(yellow)
 	t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(yellow)
+	t.Focused.ScrollUpIndicator = t.Focused.ScrollUpIndicator.Foreground(yellow)
+	t.Focused.ScrollDownIndicator = t.Focused.ScrollDownIndicator.Foreground(yellow)
 	t.Focused.Option = t.Focused.Option.Foreground(foreground)
 	t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(yellow)
 	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(green)
@@ -230,6 +242,8 @@ func ThemeDracula(isDark bool) *Styles {
 	t.Blurred.Card = t.Blurred.Base
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
+	t.Blurred.ScrollUpIndicator = lipgloss.NewStyle().SetString("  ")
+	t.Blurred.ScrollDownIndicator = lipgloss.NewStyle().SetString("  ")
 
 	t.Group.Title = t.Focused.Title
 	t.Group.Description = t.Focused.Description
@@ -251,6 +265,8 @@ func ThemeBase16(isDark bool) *Styles {
 	t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(lipgloss.Color("3"))
 	t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(lipgloss.Color("3"))
 	t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(lipgloss.Color("3"))
+	t.Focused.ScrollUpIndicator = t.Focused.ScrollUpIndicator.Foreground(lipgloss.Color("3"))
+	t.Focused.ScrollDownIndicator = t.Focused.ScrollDownIndicator.Foreground(lipgloss.Color("3"))
 	t.Focused.Option = t.Focused.Option.Foreground(lipgloss.Color("7"))
 	t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(lipgloss.Color("3"))
 	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(lipgloss.Color("2"))
@@ -274,6 +290,8 @@ func ThemeBase16(isDark bool) *Styles {
 
 	t.Blurred.NextIndicator = lipgloss.NewStyle()
 	t.Blurred.PrevIndicator = lipgloss.NewStyle()
+	t.Blurred.ScrollUpIndicator = lipgloss.NewStyle().SetString("  ")
+	t.Blurred.ScrollDownIndicator = lipgloss.NewStyle().SetString("  ")
 
 	t.Group.Title = t.Focused.Title
 	t.Group.Description = t.Focused.Description
@@ -314,6 +332,8 @@ func ThemeCatppuccin(isDark bool) *Styles {
 	t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(pink)
 	t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(pink)
 	t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(pink)
+	t.Focused.ScrollUpIndicator = t.Focused.ScrollUpIndicator.Foreground(pink)
+	t.Focused.ScrollDownIndicator = t.Focused.ScrollDownIndicator.Foreground(pink)
 	t.Focused.Option = t.Focused.Option.Foreground(text)
 	t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(pink)
 	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(green)


### PR DESCRIPTION
Disclaimer: tool assisted change, but with heavy cleanups

Select and MultiSelect have this issue that there is no visual indication showing if there is items outside of the visible range. This leads to viewer being mislead of confused, not recognising what could be selected or what is selected at the moment. Paired with pre-selecting fields that trigger pre-scrolling, extreme case can show a single selected items while there is more items available when scrolling up.

This PR adds scrolling indicators for both Select and MultiSelect, with the behavior descrived below:

## Scroll indicators for Select and MultiSelect

### Basic indicator placement

When the list is taller than the visible area, arrows appear **inline** on the first and last visible items to signal hidden content. The field height never changes.

```
┌─────────────────┐
│ Pick a fruit    │         Items above are hidden → ↑ on first visible line
│ ↑ Apple         │  ← scroll up indicator, on same line as item text
│   Banana        │
│ > Cherry        │  ← cursor
│   Date          │
│ ↓ Elderberry    │  ← scroll down indicator
└─────────────────┘         Items below are hidden → ↓ on last visible line
```

No new rows are added — the arrows share the line with the option text.

---

### No hidden content → no indicator

When all items fit in the viewport, or when the cursor has reached the actual end of the list, there is simply nothing to indicate.

```
┌─────────────────┐
│ Pick a fruit    │
│   Apple         │  ← no ↑: nothing is hidden above
│   Banana        │
│   Cherry        │
│ > Date          │  ← no ↓: nothing is hidden below
└─────────────────┘
```

---

### Arrow suppressed when cursor is on the edge item

If the cursor happens to sit on the first or last visible item while content is hidden in that direction, that arrow is omitted — it can't share the line with the cursor.

```
┌─────────────────┐
│ Pick a fruit    │         Items above are still hidden, but ↑ is suppressed
│ > Apple         │  ← cursor here, so no ↑ on this line
│   Banana        │
│   Cherry        │
│ ↓ Date          │
└─────────────────┘
```

---

### Lookahead scrolling keeps the indicator alive

When navigating, the viewport scrolls **one item early** so the indicator stays visible. The cursor rests at second-from-edge while more content exists in that direction.

Pressing **↓** repeatedly (items 1–8, viewport shows 4 at a time):

```
Step 1 — cursor on item 2      Step 2 — cursor on item 3      Step 3 — cursor on item 4
┌─────────────┐                ┌─────────────┐                ┌─────────────┐
│   Item 1    │                │   Item 1    │                │   Item 2    │
│ > Item 2    │  ← cursor      │   Item 2    │                │   Item 3    │
│   Item 3    │                │ > Item 3    │  ← cursor      │ > Item 4    │  ← cursor
│ ↓ Item 4    │  ← indicator   │ ↓ Item 4    │  ← indicator   │ ↓ Item 5    │  ← indicator
└─────────────┘                └─────────────┘                └─────────────┘
                                                               viewport scrolled
```

The cursor never lands on the ↓ row while more items exist below — the viewport shifts to keep one item ahead visible.

Once the cursor reaches the **actual last item**, there is nothing below, so the indicator disappears and the cursor sits at the bottom naturally:

```
┌─────────────┐
│   Item 5    │
│   Item 6    │
│   Item 7    │
│ > Item 8    │  ← last item, no ↓ indicator
└─────────────┘
```

---

### Small viewport (≤ 2 items visible) — no indicators

With only 1 or 2 items visible there is no room to maintain the lookahead invariant, so indicators are suppressed and normal cursor-tracking scrolling is used instead.

```
┌─────────────┐
│ > Item 3    │  ← no ↑, no ↓, even if items exist above and below
│   Item 4    │
└─────────────┘
```

---

### Inline select — no indicators

The horizontal single-item select already has its own `←` / `→` navigation indicators and is unaffected.

```
  ← Cherry →
```

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features). --> Sorry! There is a related discussion though: https://github.com/charmbracelet/huh/discussions/591
