### PR TITLE
fix racy light/dark rendering

### DIFF
--- a/form.go
+++ b/form.go
@@ -521,6 +521,7 @@ func (f *Form) Init() tea.Cmd {
 	}
 
 	cmds = append(cmds, tea.RequestWindowSize)
+	cmds = append(cmds, tea.RequestBackgroundColor)
 	return tea.Sequence(cmds...)
 }
 

--- a/form.go
+++ b/form.go
@@ -537,6 +537,14 @@ func (f *Form) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.BackgroundColorMsg:
 		f.hasDarkBg = msg.IsDark()
+		// also propagate to non-selected groups
+		f.selector.Range(func(i int, g *Group) bool {
+			if i != f.selector.Index() {
+				m, _ := g.Update(msg)
+				f.selector.Set(i, m.(*Group))
+			}
+			return true
+		})
 	case tea.WindowSizeMsg:
 		if f.width == 0 {
 			f.selector.Range(func(_ int, group *Group) bool {

--- a/group.go
+++ b/group.go
@@ -258,15 +258,14 @@ func (g *Group) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	// Update all the fields in the group.
 	g.selector.Range(func(i int, field Field) bool {
-		switch msg := msg.(type) {
+		switch msg.(type) {
 		case tea.KeyPressMsg, tea.PasteMsg:
-			break
+			if g.selector.Index() == i {
+				m, cmd := field.Update(msg)
+				g.selector.Set(i, m.(Field))
+				cmds = append(cmds, cmd)
+			}
 		default:
-			m, cmd := field.Update(msg)
-			g.selector.Set(i, m.(Field))
-			cmds = append(cmds, cmd)
-		}
-		if g.selector.Index() == i {
 			m, cmd := field.Update(msg)
 			g.selector.Set(i, m.(Field))
 			cmds = append(cmds, cmd)

--- a/theme.go
+++ b/theme.go
@@ -141,7 +141,7 @@ func ThemeCharm(isDark bool) *Styles {
 	lightDark := lipgloss.LightDark(isDark)
 
 	var (
-		normalFg = lightDark(lipgloss.Color("252"), lipgloss.Color("235"))
+		normalFg = lightDark(lipgloss.Color("235"), lipgloss.Color("252"))
 		indigo   = lightDark(lipgloss.Color("#5A56E0"), lipgloss.Color("#7571F9"))
 		cream    = lightDark(lipgloss.Color("#FFFDF5"), lipgloss.Color("#FFFDF5"))
 		fuchsia  = lipgloss.Color("#F780E2")
@@ -168,7 +168,7 @@ func ThemeCharm(isDark bool) *Styles {
 	t.Focused.UnselectedOption = t.Focused.UnselectedOption.Foreground(normalFg)
 	t.Focused.FocusedButton = t.Focused.FocusedButton.Foreground(cream).Background(fuchsia)
 	t.Focused.Next = t.Focused.FocusedButton
-	t.Focused.BlurredButton = t.Focused.BlurredButton.Foreground(normalFg).Background(lightDark(lipgloss.Color("237"), lipgloss.Color("252")))
+	t.Focused.BlurredButton = t.Focused.BlurredButton.Foreground(normalFg).Background(lightDark(lipgloss.Color("252"), lipgloss.Color("237")))
 
 	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(green)
 	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(lightDark(lipgloss.Color("248"), lipgloss.Color("238")))


### PR DESCRIPTION
Forms were racingly rendered with light-theme colors regardless of the terminal background, due to three related bugs:
   
  - fix(theme): fix swapped light/dark colors in `ThemeCharm.`  This is a regression that happened in commit 47e59e9
  - fix(form): explicitely request the background color. Before, this was relying on a side effect of `compat.HasDarkBackground` in lipgloss (package level var) triggering the terminal request, which would eventually flow back to the form. This makes it explicit and execute in all cases. Arguably, `compat.HasDarkBackground` can cause problems as it queries `(os.Stdin, os.Stdout)` instead of the real input/output of the form.
  - fix(form): propagate background color message to un-selected groups too

Additionally:
- fix(group): don't propagate events twice. Previously, message other than `tea.KeyPressMsg, tea.PasteMsg` were propagated twice. This also makes the code more obvious.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Before fix:
<img width="744" height="193" alt="image" src="https://github.com/user-attachments/assets/b4cdebf7-f9bb-4630-bc4c-2411d0c650ee" />


After fix:
<img width="744" height="193" alt="image" src="https://github.com/user-attachments/assets/5d69ceb4-fc19-42e0-99e0-43ebd2deb1dc" />
