### PR TITLE
fix(input): apply blurred styles when input is not focused

### DIFF
--- a/field_input.go
+++ b/field_input.go
@@ -386,9 +386,15 @@ func (i *Input) View() string {
 	// however.
 	st := i.textinput.Styles()
 	st.Cursor.Color = styles.TextInput.Cursor.GetForeground()
-	st.Focused.Prompt = styles.TextInput.Prompt
-	st.Focused.Text = styles.TextInput.Text
-	st.Focused.Placeholder = styles.TextInput.Placeholder
+	if i.focused {
+		st.Focused.Prompt = styles.TextInput.Prompt
+		st.Focused.Text = styles.TextInput.Text
+		st.Focused.Placeholder = styles.TextInput.Placeholder
+	} else {
+		st.Blurred.Prompt = styles.TextInput.Prompt
+		st.Blurred.Text = styles.TextInput.Text
+		st.Blurred.Placeholder = styles.TextInput.Placeholder
+	}
 	i.textinput.SetStyles(st)
 
 	// Adjust text input size to its char limit if it fit in its width


### PR DESCRIPTION
## Description

The `Input` field's `View()` method only set `st.Focused.*` styles on the underlying textinput component, regardless of whether the input was actually focused. When a custom theme configured blurred text input styles (e.g., dimmed text color, different prompt style), they were never applied.

## Root cause

`field_input.go:389-391` unconditionally set `st.Focused.Prompt`, `st.Focused.Text`, and `st.Focused.Placeholder`. The `st.Blurred.*` counterparts were never set, so the textinput component always rendered with focused styles even when blurred.

Compare with `field_text.go:381-391`, which correctly uses `if t.focused` to conditionally set either focused or blurred styles.

## Fix

Use the same pattern as `field_text.go`: check `i.focused` and set the appropriate style group.

```go
if i.focused {
    st.Focused.Prompt = styles.TextInput.Prompt
    st.Focused.Text = styles.TextInput.Text
    st.Focused.Placeholder = styles.TextInput.Placeholder
} else {
    st.Blurred.Prompt = styles.TextInput.Prompt
    st.Blurred.Text = styles.TextInput.Text
    st.Blurred.Placeholder = styles.TextInput.Placeholder
}
```

Fixes #770