### PR TITLE
Scope navigation messages to their originating form

### DIFF
--- a/field_confirm.go
+++ b/field_confirm.go
@@ -16,6 +16,7 @@ type Confirm struct {
 	accessor Accessor[bool]
 	key      string
 	id       int
+	formID   int
 
 	// customization
 	title       Eval[string]
@@ -169,6 +170,9 @@ func (c *Confirm) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.BackgroundColorMsg:
 		c.hasDarkBg = msg.IsDark()
 	case updateFieldMsg:
+		if msg.id != 0 {
+			c.formID = msg.id
+		}
 		if ok, hash := c.title.shouldUpdate(); ok {
 			c.title.bindingsHash = hash
 			if !c.title.loadFromCache() {
@@ -207,15 +211,19 @@ func (c *Confirm) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 			c.accessor.Set(!c.accessor.Get())
 		case key.Matches(msg, c.keymap.Prev):
-			cmds = append(cmds, PrevField)
+			id := c.formID
+			cmds = append(cmds, func() tea.Msg { return prevFieldMsg{id: id} })
 		case key.Matches(msg, c.keymap.Next, c.keymap.Submit):
-			cmds = append(cmds, NextField)
+			id := c.formID
+			cmds = append(cmds, func() tea.Msg { return nextFieldMsg{id: id} })
 		case key.Matches(msg, c.keymap.Accept):
 			c.accessor.Set(true)
-			cmds = append(cmds, NextField)
+			id := c.formID
+			cmds = append(cmds, func() tea.Msg { return nextFieldMsg{id: id} })
 		case key.Matches(msg, c.keymap.Reject):
 			c.accessor.Set(false)
-			cmds = append(cmds, NextField)
+			id := c.formID
+			cmds = append(cmds, func() tea.Msg { return nextFieldMsg{id: id} })
 		}
 	}
 

--- a/field_filepicker.go
+++ b/field_filepicker.go
@@ -21,6 +21,7 @@ type FilePicker struct {
 	accessor Accessor[string]
 	key      string
 	picker   filepicker.Model
+	formID   int
 
 	// state
 	focused bool
@@ -205,7 +206,12 @@ func (f *FilePicker) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.BackgroundColorMsg:
 		f.hasDarkBg = msg.IsDark()
+	case updateFieldMsg:
+		if msg.id != 0 {
+			f.formID = msg.id
+		}
 	case tea.KeyPressMsg:
+		id := f.formID
 		switch {
 		case key.Matches(msg, f.keymap.Open):
 			if f.picking {
@@ -215,13 +221,13 @@ func (f *FilePicker) Update(msg tea.Msg) (Model, tea.Cmd) {
 			return f, f.picker.Init()
 		case key.Matches(msg, f.keymap.Close):
 			f.setPicking(false)
-			return f, NextField
+			return f, func() tea.Msg { return nextFieldMsg{id: id} }
 		case key.Matches(msg, f.keymap.Next):
 			f.setPicking(false)
-			return f, NextField
+			return f, func() tea.Msg { return nextFieldMsg{id: id} }
 		case key.Matches(msg, f.keymap.Prev):
 			f.setPicking(false)
-			return f, PrevField
+			return f, func() tea.Msg { return prevFieldMsg{id: id} }
 		}
 	}
 
@@ -231,7 +237,8 @@ func (f *FilePicker) Update(msg tea.Msg) (Model, tea.Cmd) {
 	if didSelect {
 		f.accessor.Set(file)
 		f.setPicking(false)
-		return f, NextField
+		id := f.formID
+		return f, func() tea.Msg { return nextFieldMsg{id: id} }
 	}
 	didSelect, _ = f.picker.DidSelectDisabledFile(msg)
 	if didSelect {

--- a/field_input.go
+++ b/field_input.go
@@ -24,6 +24,7 @@ type Input struct {
 	accessor Accessor[string]
 	key      string
 	id       int
+	formID   int
 
 	title       Eval[string]
 	description Eval[string]
@@ -279,6 +280,9 @@ func (i *Input) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.BackgroundColorMsg:
 		i.hasDarkBg = msg.IsDark()
 	case updateFieldMsg:
+		if msg.id != 0 {
+			i.formID = msg.id
+		}
 		var cmds []tea.Cmd
 		if ok, hash := i.title.shouldUpdate(); ok {
 			i.title.bindingsHash = hash
@@ -346,14 +350,16 @@ func (i *Input) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		switch {
 		case key.Matches(msg, i.keymap.Prev):
-			cmds = append(cmds, PrevField)
+			id := i.formID
+			cmds = append(cmds, func() tea.Msg { return prevFieldMsg{id: id} })
 		case key.Matches(msg, i.keymap.Next, i.keymap.Submit):
 			value := i.textinput.Value()
 			i.err = i.validate(value)
 			if i.err != nil {
 				return i, nil
 			}
-			cmds = append(cmds, NextField)
+			id := i.formID
+			cmds = append(cmds, func() tea.Msg { return nextFieldMsg{id: id} })
 		}
 	}
 

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -23,6 +23,7 @@ type MultiSelect[T comparable] struct {
 	accessor Accessor[[]T]
 	key      string
 	id       int
+	formID   int
 
 	// customization
 	title           Eval[string]
@@ -308,6 +309,9 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.BackgroundColorMsg:
 		m.hasDarkBg = msg.IsDark()
 	case updateFieldMsg:
+		if msg.id != 0 {
+			m.formID = msg.id
+		}
 		var fieldCmds []tea.Cmd
 		if ok, hash := m.title.shouldUpdate(); ok {
 			m.title.bindingsHash = hash
@@ -460,14 +464,16 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 			if m.err != nil {
 				return m, nil
 			}
-			return m, PrevField
+			id := m.formID
+			return m, func() tea.Msg { return prevFieldMsg{id: id} }
 		case key.Matches(msg, m.keymap.Next, m.keymap.Submit):
 			m.updateValue()
 			m.err = m.validate(m.accessor.Get())
 			if m.err != nil {
 				return m, nil
 			}
-			return m, NextField
+			id := m.formID
+			return m, func() tea.Msg { return nextFieldMsg{id: id} }
 		}
 
 		if m.filtering {

--- a/field_note.go
+++ b/field_note.go
@@ -15,7 +15,8 @@ import (
 // provide context around a different field. Generally, the notes are not
 // interacted with unless the note has a next button `Next(true)`.
 type Note struct {
-	id int
+	id     int
+	formID int
 
 	title       Eval[string]
 	description Eval[string]
@@ -166,6 +167,9 @@ func (n *Note) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.BackgroundColorMsg:
 		n.hasDarkBg = msg.IsDark()
 	case updateFieldMsg:
+		if msg.id != 0 {
+			n.formID = msg.id
+		}
 		var cmds []tea.Cmd
 		if ok, hash := n.title.shouldUpdate(); ok {
 			n.title.bindingsHash = hash
@@ -195,13 +199,14 @@ func (n *Note) Update(msg tea.Msg) (Model, tea.Cmd) {
 			n.description.update(msg.description)
 		}
 	case tea.KeyPressMsg:
+		id := n.formID
 		switch {
 		case key.Matches(msg, n.keymap.Prev):
-			return n, PrevField
+			return n, func() tea.Msg { return prevFieldMsg{id: id} }
 		case key.Matches(msg, n.keymap.Next, n.keymap.Submit):
-			return n, NextField
+			return n, func() tea.Msg { return nextFieldMsg{id: id} }
 		}
-		return n, NextField
+		return n, func() tea.Msg { return nextFieldMsg{id: id} }
 	}
 	return n, nil
 }

--- a/field_select.go
+++ b/field_select.go
@@ -30,6 +30,7 @@ const (
 // using j/k, up/down, or ctrl+n/ctrl+p keys.
 type Select[T comparable] struct {
 	id       int
+	formID   int
 	accessor Accessor[T]
 	key      string
 
@@ -337,6 +338,9 @@ func (s *Select[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.BackgroundColorMsg:
 		s.hasDarkBg = msg.IsDark()
 	case updateFieldMsg:
+		if msg.id != 0 {
+			s.formID = msg.id
+		}
 		var cmds []tea.Cmd
 		if ok, hash := s.title.shouldUpdate(); ok {
 			s.title.bindingsHash = hash
@@ -476,7 +480,8 @@ func (s *Select[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 				return s, nil
 			}
 			s.updateValue()
-			return s, PrevField
+			id := s.formID
+			return s, func() tea.Msg { return prevFieldMsg{id: id} }
 		case key.Matches(msg, s.keymap.Next, s.keymap.Submit):
 			if s.selected >= len(s.filteredOptions) {
 				break
@@ -488,7 +493,8 @@ func (s *Select[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 				return s, nil
 			}
 			s.updateValue()
-			return s, NextField
+			id := s.formID
+			return s, func() tea.Msg { return nextFieldMsg{id: id} }
 		}
 
 		if s.filtering {

--- a/field_text.go
+++ b/field_text.go
@@ -25,6 +25,7 @@ type Text struct {
 	accessor Accessor[string]
 	key      string
 	id       int
+	formID   int
 
 	title       Eval[string]
 	description Eval[string]
@@ -276,6 +277,9 @@ func (t *Text) Update(msg tea.Msg) (Model, tea.Cmd) {
 		cmds = append(cmds, cmd)
 		t.accessor.Set(t.textarea.Value())
 	case updateFieldMsg:
+		if msg.id != 0 {
+			t.formID = msg.id
+		}
 		var cmds []tea.Cmd
 		if ok, hash := t.placeholder.shouldUpdate(); ok {
 			t.placeholder.bindingsHash = hash
@@ -344,14 +348,16 @@ func (t *Text) Update(msg tea.Msg) (Model, tea.Cmd) {
 			if t.err != nil {
 				return t, nil
 			}
-			cmds = append(cmds, NextField)
+			id := t.formID
+			cmds = append(cmds, func() tea.Msg { return nextFieldMsg{id: id} })
 		case key.Matches(msg, t.keymap.Prev):
 			value := t.textarea.Value()
 			t.err = t.validate(value)
 			if t.err != nil {
 				return t, nil
 			}
-			cmds = append(cmds, PrevField)
+			id := t.formID
+			cmds = append(cmds, func() tea.Msg { return prevFieldMsg{id: id} })
 		}
 	}
 

--- a/form.go
+++ b/form.go
@@ -65,6 +65,10 @@ var ErrTimeoutUnsupported = errors.New("timeout is not supported in accessible m
 // The form can navigate between groups and is complete once all the groups are
 // complete.
 type Form struct {
+	// unique form ID, used to scope internal navigation messages so that
+	// multiple forms in the same bubbletea program don't interfere with each other.
+	id int
+
 	// collection of groups
 	selector *selector.Selector[*Group]
 
@@ -107,16 +111,24 @@ type Form struct {
 // Use With* methods to customize the form with options, such as setting
 // different themes and keybindings.
 func NewForm(groups ...*Group) *Form {
-	selector := selector.NewSelector(groups)
+	sel := selector.NewSelector(groups)
 
 	f := &Form{
-		selector: selector,
+		id:       nextID(),
+		selector: sel,
 		keymap:   NewDefaultKeyMap(),
 		results:  make(map[string]any),
 		layout:   LayoutDefault,
 		teaOptions: []tea.ProgramOption{
 			tea.WithOutput(os.Stderr),
 		},
+	}
+
+	// Inject the form ID into each group so that internal navigation messages
+	// can be scoped to this form and won't bleed into other forms running in
+	// the same bubbletea program.
+	for _, g := range groups {
+		g.formID = f.id
 	}
 
 	// NB: If dynamic forms come into play this will need to be applied when
@@ -211,19 +223,21 @@ func (p FieldPosition) IsLast() bool {
 }
 
 // nextGroupMsg is a message to move to the next group.
-type nextGroupMsg struct{}
+// id scopes the message to the form that sent it; 0 means accept from any.
+type nextGroupMsg struct{ id int }
 
 // prevGroupMsg is a message to move to the previous group.
-type prevGroupMsg struct{}
+// id scopes the message to the form that sent it; 0 means accept from any.
+type prevGroupMsg struct{ id int }
 
-// nextGroup is the command to move to the next group.
-func nextGroup() tea.Msg {
-	return nextGroupMsg{}
+// nextGroup returns a command that moves to the next group for form f.
+func (f *Form) nextGroup() tea.Cmd {
+	return func() tea.Msg { return nextGroupMsg{id: f.id} }
 }
 
-// prevGroup is the command to move to the previous group.
-func prevGroup() tea.Msg {
-	return prevGroupMsg{}
+// prevGroup returns a command that moves to the previous group for form f.
+func (f *Form) prevGroup() tea.Cmd {
+	return func() tea.Msg { return prevGroupMsg{id: f.id} }
 }
 
 // WithAccessible sets the form to run in accessible mode to avoid redrawing the
@@ -478,13 +492,13 @@ func (f *Form) GetBool(key string) bool {
 
 // NextGroup moves the form to the next group.
 func (f *Form) NextGroup() tea.Cmd {
-	_, cmd := f.Update(nextGroup())
+	_, cmd := f.Update(nextGroupMsg{id: f.id})
 	return cmd
 }
 
-// PrevGroup moves the form to the next group.
+// PrevGroup moves the form to the previous group.
 func (f *Form) PrevGroup() tea.Cmd {
-	_, cmd := f.Update(prevGroup())
+	_, cmd := f.Update(prevGroupMsg{id: f.id})
 	return cmd
 }
 
@@ -517,7 +531,7 @@ func (f *Form) Init() tea.Cmd {
 	})
 
 	if f.isGroupHidden(f.selector.Selected()) {
-		cmds = append(cmds, nextGroup)
+		cmds = append(cmds, f.nextGroup())
 	}
 
 	cmds = append(cmds, tea.RequestWindowSize)
@@ -569,11 +583,18 @@ func (f *Form) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 
 	case nextFieldMsg:
+		// Ignore navigation messages scoped to a different form.
+		if msg.id != 0 && msg.id != f.id {
+			break
+		}
 		// Form is progressing to the next field, let's save the value of the current field.
 		field := group.selector.Selected()
 		f.results[field.GetKey()] = field.GetValue()
 
 	case nextGroupMsg:
+		if msg.id != 0 && msg.id != f.id {
+			break
+		}
 		if len(group.Errors()) > 0 {
 			return f, nil
 		}
@@ -603,6 +624,9 @@ func (f *Form) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return f, f.selector.Selected().Init()
 
 	case prevGroupMsg:
+		if msg.id != 0 && msg.id != f.id {
+			break
+		}
 		if len(group.Errors()) > 0 {
 			return f, nil
 		}

--- a/group.go
+++ b/group.go
@@ -17,6 +17,11 @@ import (
 // If any of the fields in a group have errors, the form will not be able to
 // progress to the next group.
 type Group struct {
+	// formID is the ID of the form this group belongs to.
+	// It's used to scope internal navigation messages so multiple forms in
+	// the same bubbletea program don't interfere with each other.
+	formID int
+
 	// collection of fields
 	selector *selector.Selector[Field]
 
@@ -171,26 +176,28 @@ func (g *Group) Errors() []error {
 //
 // This is used to update all TitleFunc, DescriptionFunc, and ...Func update
 // methods to make all fields dynamically update based on user input.
-type updateFieldMsg struct{}
+// updateFieldMsg triggers dynamic field updates (title, description, etc.).
+// id scopes the message to the form that sent it; 0 means accept from any.
+type updateFieldMsg struct{ id int }
 
-// nextFieldMsg is a message to move to the next field,
-//
-// each field controls when to send this message such that it is able to use
-// different key bindings or events to trigger group progression.
-type nextFieldMsg struct{}
+// nextFieldMsg is a message to move to the next field.
+// id scopes the message to the form that sent it; 0 means accept from any.
+type nextFieldMsg struct{ id int }
 
 // prevFieldMsg is a message to move to the previous field.
-//
-// each field controls when to send this message such that it is able to use
-// different key bindings or events to trigger group progression.
-type prevFieldMsg struct{}
+// id scopes the message to the form that sent it; 0 means accept from any.
+type prevFieldMsg struct{ id int }
 
 // NextField is the command to move to the next field.
+// This sends an unscoped message (id=0) and works with any form.
+// Fields inside a form use a scoped version automatically.
 func NextField() tea.Msg {
 	return nextFieldMsg{}
 }
 
 // PrevField is the command to move to the previous field.
+// This sends an unscoped message (id=0) and works with any form.
+// Fields inside a form use a scoped version automatically.
 func PrevField() tea.Msg {
 	return prevFieldMsg{}
 }
@@ -199,7 +206,7 @@ func PrevField() tea.Msg {
 func (g *Group) Init() tea.Cmd {
 	var cmds []tea.Cmd
 
-	cmds = append(cmds, func() tea.Msg { return updateFieldMsg{} })
+	cmds = append(cmds, func() tea.Msg { return updateFieldMsg{id: g.formID} })
 
 	if g.selector.Selected().Skip() {
 		if g.selector.OnLast() {
@@ -220,14 +227,16 @@ func (g *Group) Init() tea.Cmd {
 
 // nextField moves to the next field.
 func (g *Group) nextField() []tea.Cmd {
+	id := g.formID
+	nextGrp := func() tea.Msg { return nextGroupMsg{id: id} }
 	blurCmd := g.selector.Selected().Blur()
 	if g.selector.OnLast() {
-		return []tea.Cmd{blurCmd, nextGroup}
+		return []tea.Cmd{blurCmd, nextGrp}
 	}
 	g.selector.Next()
 	for g.selector.Selected().Skip() {
 		if g.selector.OnLast() {
-			return []tea.Cmd{blurCmd, nextGroup}
+			return []tea.Cmd{blurCmd, nextGrp}
 		}
 		g.selector.Next()
 	}
@@ -237,14 +246,16 @@ func (g *Group) nextField() []tea.Cmd {
 
 // prevField moves to the previous field.
 func (g *Group) prevField() []tea.Cmd {
+	id := g.formID
+	prevGrp := func() tea.Msg { return prevGroupMsg{id: id} }
 	blurCmd := g.selector.Selected().Blur()
 	if g.selector.OnFirst() {
-		return []tea.Cmd{blurCmd, prevGroup}
+		return []tea.Cmd{blurCmd, prevGrp}
 	}
 	g.selector.Prev()
 	for g.selector.Selected().Skip() {
 		if g.selector.OnFirst() {
-			return []tea.Cmd{blurCmd, prevGroup}
+			return []tea.Cmd{blurCmd, prevGrp}
 		}
 		g.selector.Prev()
 	}
@@ -271,7 +282,9 @@ func (g *Group) Update(msg tea.Msg) (Model, tea.Cmd) {
 			g.selector.Set(i, m.(Field))
 			cmds = append(cmds, cmd)
 		}
-		m, cmd := field.Update(updateFieldMsg{})
+		// Send a scoped updateFieldMsg so fields learn the form ID and can
+		// emit correctly-scoped navigation messages.
+		m, cmd := field.Update(updateFieldMsg{id: g.formID})
 		g.selector.Set(i, m.(Field))
 		cmds = append(cmds, cmd)
 		return true
@@ -281,8 +294,15 @@ func (g *Group) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.BackgroundColorMsg:
 		g.hasDarkBg = msg.IsDark()
 	case nextFieldMsg:
+		// Ignore messages scoped to a different form.
+		if msg.id != 0 && msg.id != g.formID {
+			break
+		}
 		cmds = append(cmds, g.nextField()...)
 	case prevFieldMsg:
+		if msg.id != 0 && msg.id != g.formID {
+			break
+		}
 		cmds = append(cmds, g.prevField()...)
 	}
 

--- a/huh_test.go
+++ b/huh_test.go
@@ -869,21 +869,21 @@ func TestHideGroup(t *testing.T) {
 	}
 
 	// should have no effect as previous group is hidden
-	f.Update(prevGroup())
+	f.Update(prevGroupMsg{id: f.id})
 
 	if v := f.View(); !strings.Contains(v, "Bar") {
 		t.Log(pretty.Render(v))
 		t.Error("expected Bar to be visible")
 	}
 
-	f.Update(nextGroup())
+	f.Update(nextGroupMsg{id: f.id})
 
 	if v := f.View(); !strings.Contains(v, "Baz") {
 		t.Log(pretty.Render(v))
 		t.Error("expected Baz to be visible")
 	}
 
-	f.Update(nextGroup())
+	f.Update(nextGroupMsg{id: f.id})
 
 	if v := f.View(); strings.Contains(v, "Qux") {
 		t.Log(pretty.Render(v))
@@ -911,14 +911,14 @@ func TestHideGroupLastAndFirstGroupsNotHidden(t *testing.T) {
 	}
 
 	// should have no effect as there isn't any
-	f.Update(prevGroup())
+	f.Update(prevGroupMsg{id: f.id})
 
 	if v := f.View(); !strings.Contains(v, "Bar") {
 		t.Log(pretty.Render(v))
 		t.Error("expected Bar to not be hidden")
 	}
 
-	f.Update(nextGroup())
+	f.Update(nextGroupMsg{id: f.id})
 
 	if v := ansi.Strip(f.View()); !strings.Contains(v, "Baz") {
 		t.Log(pretty.Render(v))
@@ -926,7 +926,7 @@ func TestHideGroupLastAndFirstGroupsNotHidden(t *testing.T) {
 	}
 
 	// should submit the form
-	f.Update(nextGroup())
+	f.Update(nextGroupMsg{id: f.id})
 	if v := f.State; v != StateCompleted {
 		t.Error("should have been completed")
 	}
@@ -940,14 +940,40 @@ func TestPrevGroup(t *testing.T) {
 	)
 
 	f = batchUpdate(f, f.Init()).(*Form)
-	f.Update(nextGroup())
-	f.Update(nextGroup())
-	f.Update(prevGroup())
-	f.Update(prevGroup())
+	f.Update(nextGroupMsg{id: f.id})
+	f.Update(nextGroupMsg{id: f.id})
+	f.Update(prevGroupMsg{id: f.id})
+	f.Update(prevGroupMsg{id: f.id})
 
 	if v := ansi.Strip(f.View()); !strings.Contains(v, "Bar") {
 		t.Log(pretty.Render(v))
 		t.Error("expected Bar to not be hidden")
+	}
+}
+
+// TestMultiFormIsolation verifies that navigation messages from one form don't
+// bleed into a sibling form running in the same bubbletea program.
+func TestMultiFormIsolation(t *testing.T) {
+	f1 := NewForm(
+		NewGroup(NewNote().Description("f1-group1")),
+		NewGroup(NewNote().Description("f1-group2")),
+	)
+	f2 := NewForm(
+		NewGroup(NewNote().Description("f2-group1")),
+		NewGroup(NewNote().Description("f2-group2")),
+	)
+	f1 = batchUpdate(f1, f1.Init()).(*Form)
+	f2 = batchUpdate(f2, f2.Init()).(*Form)
+
+	// Advance f1 to its second group.
+	f1.Update(nextGroupMsg{id: f1.id})
+
+	if v := ansi.Strip(f1.View()); !strings.Contains(v, "f1-group2") {
+		t.Error("f1 should be on its second group")
+	}
+	// f2 should still be on its first group; f1's nextGroupMsg must not affect it.
+	if v := ansi.Strip(f2.View()); !strings.Contains(v, "f2-group1") {
+		t.Error("f2 should still be on its first group after f1 advanced")
 	}
 }
 


### PR DESCRIPTION
Fixes #278.

When multiple `huh.Form`s run inside the same bubbletea program, internal navigation messages (`nextFieldMsg`, `prevFieldMsg`, `nextGroupMsg`, `prevGroupMsg`, `updateFieldMsg`) were broadcast with no form identity attached. Any sibling form that received one would also advance its fields or groups, causing the "jumping fields" behavior from the issue.

The fix is inspired by the same ID-scoping pattern used in `charm.land/bubbles/spinner`. Each `Form` gets a unique integer ID via the existing `nextID()` function. Every internal navigation message carries that ID. Forms and groups check it before acting, and ignore messages from a different form. `id=0` is treated as "unscoped" (for backwards compat with the exported `NextField`/`PrevField` API).

Fields learn the form ID through `updateFieldMsg`, which the group already sends on every update cycle. They store it and use it when emitting navigation commands, so a field in form A can't trigger navigation in form B.

I added `TestMultiFormIsolation` which runs two forms concurrently and verifies that advancing one doesn't affect the other.