### PR TITLE
Input: apply blurred styles when the field isn't focused

### DIFF
--- a/field_input.go
+++ b/field_input.go
@@ -386,9 +386,15 @@ func (i *Input) View() string {
 	// however.
 	st := i.textinput.Styles()
 	st.Cursor.Color = styles.TextInput.Cursor.GetForeground()
-	st.Focused.Prompt = styles.TextInput.Prompt
-	st.Focused.Text = styles.TextInput.Text
-	st.Focused.Placeholder = styles.TextInput.Placeholder
+	if i.focused {
+		st.Focused.Prompt = styles.TextInput.Prompt
+		st.Focused.Text = styles.TextInput.Text
+		st.Focused.Placeholder = styles.TextInput.Placeholder
+	} else {
+		st.Blurred.Prompt = styles.TextInput.Prompt
+		st.Blurred.Text = styles.TextInput.Text
+		st.Blurred.Placeholder = styles.TextInput.Placeholder
+	}
 	i.textinput.SetStyles(st)
 
 	// Adjust text input size to its char limit if it fit in its width


### PR DESCRIPTION
Closes #770.

`Input.View` only ever writes to `st.Focused`, so themes that customise `Blurred.TextInput` stop taking effect once the field loses focus. v1 used to branch on focus state and the sibling `Text.View` still does. Mirror that pattern.