### PR TITLE
fix: skip hidden groups in accessible mode

### DIFF
--- a/form.go
+++ b/form.go
@@ -725,6 +725,9 @@ func (f *Form) runAccessible(w io.Writer, r io.Reader) error {
 	}
 
 	f.selector.Range(func(_ int, group *Group) bool {
+		if f.isGroupHidden(group) {
+			return true
+		}
 		group.selector.Range(func(_ int, field Field) bool {
 			field.Init()
 			field.Focus()

--- a/huh_test.go
+++ b/huh_test.go
@@ -1268,6 +1268,102 @@ func TestAccessibleForm(t *testing.T) {
 	}
 }
 
+func TestAccessibleFormSkipsHiddenGroup(t *testing.T) {
+	var out bytes.Buffer
+	var visible, hidden string
+
+	f := NewForm(
+		NewGroup(
+			NewInput().Title("Visible:").Value(&visible),
+		),
+		NewGroup(
+			NewInput().Title("Hidden:").Value(&hidden),
+		).WithHide(true),
+	).
+		WithAccessible(true).
+		WithOutput(&out).
+		WithInput(strings.NewReader("carlos\n"))
+
+	if err := f.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out.String(), "Visible:") {
+		t.Error("expected visible group to be prompted, output:\n", out.String())
+	}
+	if strings.Contains(out.String(), "Hidden:") {
+		t.Error("expected hidden group to be skipped, output:\n", out.String())
+	}
+	if visible != "carlos" {
+		t.Errorf("expected visible field value to be %q, got %q", "carlos", visible)
+	}
+	if hidden != "" {
+		t.Errorf("expected hidden field value to be empty, got %q", hidden)
+	}
+}
+
+func TestAccessibleFormSkipsDynamicallyHiddenGroup(t *testing.T) {
+	var out bytes.Buffer
+	var visible, hidden string
+
+	f := NewForm(
+		NewGroup(
+			NewInput().Title("Visible:").Value(&visible),
+		),
+		NewGroup(
+			NewInput().Title("Hidden:").Value(&hidden),
+		).WithHideFunc(func() bool { return true }),
+	).
+		WithAccessible(true).
+		WithOutput(&out).
+		WithInput(strings.NewReader("carlos\n"))
+
+	if err := f.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out.String(), "Visible:") {
+		t.Error("expected visible group to be prompted, output:\n", out.String())
+	}
+	if strings.Contains(out.String(), "Hidden:") {
+		t.Error("expected dynamically hidden group to be skipped, output:\n", out.String())
+	}
+	if visible != "carlos" {
+		t.Errorf("expected visible field value to be %q, got %q", "carlos", visible)
+	}
+	if hidden != "" {
+		t.Errorf("expected hidden field value to be empty, got %q", hidden)
+	}
+}
+
+func TestAccessibleFormAllGroupsHidden(t *testing.T) {
+	var out bytes.Buffer
+	var a, b string
+
+	f := NewForm(
+		NewGroup(
+			NewInput().Title("A:").Value(&a),
+		).WithHide(true),
+		NewGroup(
+			NewInput().Title("B:").Value(&b),
+		).WithHideFunc(func() bool { return true }),
+	).
+		WithAccessible(true).
+		WithOutput(&out).
+		WithInput(strings.NewReader(""))
+
+	if err := f.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(out.String(), "A:") || strings.Contains(out.String(), "B:") {
+		t.Error("expected no group to be prompted, output:\n", out.String())
+	}
+	if a != "" || b != "" {
+		t.Errorf("expected both field values to be empty, got a=%q b=%q", a, b)
+	}
+}
+
 func TestAccessibleFields(t *testing.T) {
 	for name, test := range map[string]struct {
 		Field       Field


### PR DESCRIPTION
## Summary

One-line behavior fix: `Form.runAccessible` iterated every group regardless of hide state, so groups marked with `WithHide(true)` or `WithHideFunc(...)` were still prompted in accessible mode. The interactive path already guards against this via `f.isGroupHidden(group)` (see `form.go:377, 386, 592, 611`).

This adds the same check to the accessible path so behavior matches.

## Changes

- `form.go` — skip group in `runAccessible` when `f.isGroupHidden(group)` returns true
- `huh_test.go` — three new tests:
  - `TestAccessibleFormSkipsHiddenGroup` — static `WithHide(true)`
  - `TestAccessibleFormSkipsDynamicallyHiddenGroup` — dynamic `WithHideFunc`
  - `TestAccessibleFormAllGroupsHidden` — all groups hidden, no prompts, empty values

## Test plan

- [x] New tests fail on `main` (hidden group prompted, input consumed)
- [x] New tests pass after fix
- [x] Full suite green (`go test ./...`)