### PR TITLE
feat: add new modal component that can overay forms and other content…

### DIFF
--- a/examples/modal/main.go
+++ b/examples/modal/main.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"charm.land/bubbles/v2/table"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/huh/v2"
+	"charm.land/huh/v2/modal"
+	"charm.land/lipgloss/v2"
+)
+
+const wizardID = "character-wizard"
+
+var (
+	titleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FAFAFA")).
+			Background(lipgloss.Color("#874BFD")).
+			Padding(0, 1)
+
+	helpStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241"))
+
+	tableBorderStyle = lipgloss.NewStyle().
+				BorderStyle(lipgloss.NormalBorder()).
+				BorderForeground(lipgloss.Color("240"))
+
+	backgroundStyle = lipgloss.NewStyle().Padding(2, 4)
+)
+
+type character struct {
+	class     string
+	level     string
+	eyeColor  string
+	hairColor string
+}
+
+type model struct {
+	width, height int
+	modal         *modal.Modal
+	characters    []character
+	table         table.Model
+	lastCancelled bool
+}
+
+func newModel() model {
+	cols := []table.Column{
+		{Title: "#", Width: 3},
+		{Title: "Class", Width: 9},
+		{Title: "Level", Width: 6},
+		{Title: "Eyes", Width: 7},
+		{Title: "Hair", Width: 7},
+	}
+
+	t := table.New(
+		table.WithColumns(cols),
+		table.WithFocused(true),
+		table.WithHeight(8),
+		table.WithWidth(40),
+	)
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		BorderBottom(true).
+		Bold(true)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.Color("229")).
+		Background(lipgloss.Color("57")).
+		Bold(false)
+	t.SetStyles(s)
+
+	return model{table: t}
+}
+
+func (m model) Init() tea.Cmd { return nil }
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+
+	case modal.ResolvedMsg:
+		if msg.ID == wizardID {
+			confirmed := msg.Confirmed
+			var saved *character
+			if confirmed {
+				form := msg.Value.(*huh.Form)
+				if form.GetBool("ok") {
+					c := character{
+						class:     form.GetString("class"),
+						level:     form.GetString("level"),
+						eyeColor:  form.GetString("eyeColor"),
+						hairColor: form.GetString("hairColor"),
+					}
+					saved = &c
+				} else {
+					confirmed = false
+				}
+			}
+			if saved != nil {
+				m.characters = append(m.characters, *saved)
+				m.refreshRows()
+				m.lastCancelled = false
+			} else {
+				m.lastCancelled = !confirmed
+			}
+			m.modal = nil
+		}
+		return m, nil
+	}
+
+	// While a modal is open, route messages to it exclusively.
+	if m.modal != nil {
+		var cmd tea.Cmd
+		m.modal, cmd = m.modal.Update(msg)
+		return m, cmd
+	}
+
+	if key, ok := msg.(tea.KeyPressMsg); ok {
+		switch key.String() {
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		case "n":
+			m.modal = newWizard()
+			return m, m.modal.Init()
+		}
+	}
+
+	var cmd tea.Cmd
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+func (m *model) refreshRows() {
+	rows := make([]table.Row, len(m.characters))
+	for i, c := range m.characters {
+		rows[i] = table.Row{strconv.Itoa(i + 1), c.class, c.level, c.eyeColor, c.hairColor}
+	}
+	m.table.SetRows(rows)
+}
+
+func (m model) View() tea.View {
+	bg := m.backgroundContent()
+	bg = lipgloss.Place(m.width, m.height, lipgloss.Top, lipgloss.Left, bg)
+
+	v := tea.NewView(bg)
+	v.AltScreen = true
+	if m.modal != nil {
+		v.SetContent(m.modal.Render(bg, m.width, m.height))
+	}
+	return v
+}
+
+func (m model) backgroundContent() string {
+	body := titleStyle.Render(" Character Roster ") + "\n\n"
+	body += tableBorderStyle.Render(m.table.View()) + "\n"
+
+	if m.lastCancelled {
+		body += "\n" + helpStyle.Render("(last wizard cancelled — nothing saved)")
+	}
+
+	body += "\n\n" + helpStyle.Render("n — new character • ↑/↓ — navigate • q — quit")
+	return backgroundStyle.Render(body)
+}
+
+func newWizard() *modal.Modal {
+	colors := huh.NewOptions("Brown", "Black", "Green")
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Key("class").
+				Title("Choose your class").
+				Options(huh.NewOptions("Warrior", "Mage", "Rogue")...),
+
+			huh.NewSelect[string]().
+				Key("level").
+				Title("Choose your level").
+				Options(huh.NewOptions("1", "20", "9999")...),
+		),
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Key("eyeColor").
+				Title("Choose your eye color").
+				Options(colors...),
+
+			huh.NewSelect[string]().
+				Key("hairColor").
+				Title("Choose your hair color").
+				Options(colors...),
+
+			huh.NewConfirm().
+				Key("ok").
+				Title("Save this character?").
+				Affirmative("Save").
+				Negative("Cancel"),
+		),
+	).
+		WithWidth(45).
+		WithShowHelp(true)
+
+	return modal.NewForm(wizardID, form)
+}
+
+func main() {
+	if _, err := tea.NewProgram(newModel()).Run(); err != nil {
+		fmt.Println("error:", err)
+		os.Exit(1)
+	}
+}

--- a/modal/form.go
+++ b/modal/form.go
@@ -1,0 +1,44 @@
+package modal
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"charm.land/huh/v2"
+)
+
+// formContent adapts a [huh.Form] to the [Content] interface. The form's
+// own State drives the modal's resolution: [huh.StateCompleted] → confirmed,
+// [huh.StateAborted] → cancelled.
+type formContent struct {
+	form *huh.Form
+}
+
+func (f *formContent) Init() tea.Cmd { return f.form.Init() }
+
+func (f *formContent) Update(msg tea.Msg) (Content, tea.Cmd) {
+	model, cmd := f.form.Update(msg)
+	if updated, ok := model.(*huh.Form); ok {
+		f.form = updated
+	}
+	return f, cmd
+}
+
+func (f *formContent) View() string { return f.form.View() }
+
+func (f *formContent) Done() (done, confirmed bool, value any) {
+	switch f.form.State {
+	case huh.StateCompleted:
+		return true, true, f.form
+	case huh.StateAborted:
+		return true, false, nil
+	default:
+		return false, false, nil
+	}
+}
+
+// NewForm constructs a Modal that hosts a huh form. When the form completes
+// the modal resolves with Confirmed=true and Value set to the [*huh.Form]
+// (read field values via [huh.Form.GetString] etc.). When the user aborts
+// the form (esc by default) the modal resolves with Confirmed=false.
+func NewForm(id string, form *huh.Form, opts ...Option) *Modal {
+	return New(id, &formContent{form: form}, opts...)
+}

--- a/modal/modal.go
+++ b/modal/modal.go
@@ -1,0 +1,157 @@
+// Package modal provides a reusable overlay-dialog component for Bubble Tea v2
+// applications, built on top of the lipgloss v2 compositor.
+//
+// A Modal wraps any [Content] (typically a [huh.Form]) and is rendered as a
+// layer stacked on top of the parent application. While a modal is open the
+// parent should route messages to it exclusively, which gives the modal
+// exclusive focus until it resolves.
+//
+// Lifecycle:
+//
+//  1. Construct a Modal with [New] (or [NewForm] for a huh.Form).
+//  2. The parent owns the modal as an optional field (nil = closed).
+//  3. On every parent Update, if the field is non-nil forward the message
+//     to Modal.Update only, then watch the returned command for a [ResolvedMsg].
+//  4. On [ResolvedMsg], inspect Confirmed and Value, then clear the field.
+//  5. On every parent View, if the field is non-nil call [Modal.Render] to
+//     composite it over the background string.
+package modal
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// Content is anything that can live inside a [Modal]. It mirrors the standard
+// Bubble Tea model lifecycle plus a [Content.Done] check that lets the modal
+// know when to resolve.
+type Content interface {
+	Init() tea.Cmd
+	Update(tea.Msg) (Content, tea.Cmd)
+	View() string
+	// Done reports whether the content has resolved. When done is true the
+	// modal will emit a [ResolvedMsg] carrying confirmed and value. A
+	// cancelled resolution should return (true, false, nil).
+	Done() (done bool, confirmed bool, value any)
+}
+
+// ResolvedMsg is dispatched once when the modal's [Content] reports done.
+// Parents should clear their modal field on receipt and react to Confirmed
+// and Value as appropriate.
+type ResolvedMsg struct {
+	ID        string
+	Confirmed bool
+	Value     any
+}
+
+// Modal wraps a [Content] for rendering as a centered overlay layer.
+type Modal struct {
+	id       string
+	content  Content
+	style    lipgloss.Style
+	z        int
+	resolved bool
+}
+
+// Option configures a [Modal] at construction time.
+type Option func(*Modal)
+
+// WithStyle wraps the content with the given lipgloss style (typically a
+// bordered, padded box). Defaults to a rounded border with single-cell
+// padding.
+func WithStyle(s lipgloss.Style) Option {
+	return func(m *Modal) { m.style = s }
+}
+
+// WithZ sets the z-index of the modal layer. Defaults to 10. Higher values
+// render on top of lower ones when multiple modals are stacked.
+func WithZ(z int) Option {
+	return func(m *Modal) { m.z = z }
+}
+
+// defaultStyle is a rounded-border dialog box. Callers can override via
+// [WithStyle].
+var defaultStyle = lipgloss.NewStyle().
+	Border(lipgloss.RoundedBorder()).
+	BorderForeground(lipgloss.Color("#874BFD")).
+	Padding(1, 2)
+
+// New constructs a Modal for the given Content. The id is used to identify
+// the modal in [ResolvedMsg] (and as the layer ID for hit testing).
+func New(id string, content Content, opts ...Option) *Modal {
+	m := &Modal{
+		id:      id,
+		content: content,
+		style:   defaultStyle,
+		z:       10,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// ID returns the modal's identifier.
+func (m *Modal) ID() string { return m.id }
+
+// Init returns the underlying content's initial command.
+func (m *Modal) Init() tea.Cmd {
+	return m.content.Init()
+}
+
+// Update forwards the message to the content. If the content reports it is
+// done, Update also emits a [ResolvedMsg]. Once resolved the modal becomes
+// inert — further Update calls are no-ops.
+func (m *Modal) Update(msg tea.Msg) (*Modal, tea.Cmd) {
+	if m.resolved {
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.content, cmd = m.content.Update(msg)
+	done, confirmed, value := m.content.Done()
+	if !done {
+		return m, cmd
+	}
+	m.resolved = true
+	id := m.id
+	resolveCmd := func() tea.Msg {
+		return ResolvedMsg{ID: id, Confirmed: confirmed, Value: value}
+	}
+	if cmd == nil {
+		return m, resolveCmd
+	}
+	return m, tea.Batch(cmd, resolveCmd)
+}
+
+// View renders the styled content as a plain string (no compositing). Use
+// [Modal.Layer] or [Modal.Render] for placement over a background.
+func (m *Modal) View() string {
+	return m.style.Render(m.content.View())
+}
+
+// Layer returns the modal as a positioned lipgloss layer, centered within a
+// canvas of size (parentW, parentH). Use this when assembling your own layer
+// tree; for the simple "background + one modal" case prefer [Modal.Render].
+func (m *Modal) Layer(parentW, parentH int) *lipgloss.Layer {
+	view := m.View()
+	w := lipgloss.Width(view)
+	h := lipgloss.Height(view)
+	x := (parentW - w) / 2
+	y := (parentH - h) / 2
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+	return lipgloss.NewLayer(view).ID(m.id).X(x).Y(y).Z(m.z)
+}
+
+// Render composites the modal over background and returns the final string
+// ready to drop into tea.View.Content. parentW and parentH must match the
+// dimensions of background so centering is correct.
+func (m *Modal) Render(background string, parentW, parentH int) string {
+	root := lipgloss.NewLayer(background).ID("modal-background")
+	root.AddLayers(m.Layer(parentW, parentH))
+	return lipgloss.NewCompositor(root).Render()
+}


### PR DESCRIPTION
# Add `modal` package for overlay dialogs

## Summary

- New `charm.land/huh/v2/modal` package: a small overlay-dialog component that
  composites a styled box (containing arbitrary `Content` — typically a
  `huh.Form`) over a parent Bubble Tea view using lipgloss v2's layer
  compositor.
- `modal.NewForm(id, form)` is the one-liner for the common case of putting a
  `*huh.Form` in a modal; for anything else, implement the `modal.Content`
  interface (`Init`/`Update`/`View`/`Done`).
- Modals resolve by emitting a `modal.ResolvedMsg{ID, Confirmed, Value}` once
  the embedded content reports done (`huh.StateCompleted` → confirmed,
  `huh.StateAborted` → cancelled).
- Style and z-index are configurable via `WithStyle` / `WithZ`. The default is
  a rounded purple-bordered dialog at z=10.
- New `examples/modal` showcases the package with a character-roster app: a
  Bubble Tea table on the background, press `n` to open a two-group huh
  wizard modal, results land back in the roster on confirm.

## Lifecycle (for reviewers)

The parent owns the modal as an optional `*modal.Modal` field (`nil` = closed).
While non-nil:

1. Forward every `tea.Msg` to `modal.Update` exclusively (focus stealing).
2. On `modal.ResolvedMsg`, read `Confirmed`/`Value`, then clear the field.
3. On `View`, call `modal.Render(background, w, h)` to composite the dialog
   over the parent's content; otherwise render the background as usual.

## Test plan

- [ ] `go build ./...` and `go vet ./...` from repo root
- [ ] `go build ./...` and `go vet ./...` from `examples/`
- [ ] `cd examples && go run ./modal` — verify:
  - [ ] `n` opens the wizard centered over the roster
  - [ ] completing the wizard (Save) adds a row to the table
  - [ ] cancelling via the Confirm field shows the cancelled hint
  - [ ] aborting with `esc` also shows the cancelled hint
  - [ ] `q` / `ctrl+c` quits from the background
  - [ ] background keys (`j`/`k`, arrow keys) are inert while the modal is open
