### PR TITLE
fix: allow Shift+Tab to navigate back even when fields have validation errors

### DIFF
--- a/field_text.go
+++ b/field_text.go
@@ -346,11 +346,6 @@ func (t *Text) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 			cmds = append(cmds, NextField)
 		case key.Matches(msg, t.keymap.Prev):
-			value := t.textarea.Value()
-			t.err = t.validate(value)
-			if t.err != nil {
-				return t, nil
-			}
 			cmds = append(cmds, PrevField)
 		}
 	}

--- a/form.go
+++ b/form.go
@@ -603,10 +603,6 @@ func (f *Form) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return f, f.selector.Selected().Init()
 
 	case prevGroupMsg:
-		if len(group.Errors()) > 0 {
-			return f, nil
-		}
-
 		for i := f.selector.Index() - 1; i >= 0; i-- {
 			if !f.isGroupHidden(f.selector.Get(i)) {
 				f.selector.SetIndex(i)


### PR DESCRIPTION
## Problem

When a form field has a validation error, pressing **Shift+Tab** to navigate backward to a previous group is blocked. The user is trapped on the current page until they fix the validation error, even though backward navigation doesn't require valid input on the current field.

### Root cause

Two issues:

1. **`form.go` `prevGroupMsg` handler** checks `len(group.Errors()) > 0` and blocks backward navigation. Errors should only block forward navigation (`nextGroupMsg`), not backward.

2. **`field_text.go` `Prev` keypress handler** validates the value and refuses to send `PrevField` on error, unlike `Input` which skips validation on Prev and allows going back.

Additionally, all field types validate on `Blur()`, which is called before `prevGroup` is sent — so even if the field cleared its error during key handling, `Blur()` re-sets it.

## Changes

- **`form.go`**: Remove the error check from `prevGroupMsg`. Forward navigation (`nextGroupMsg`) still blocks on errors — only backward navigation is relaxed.
- **`field_text.go`**: Skip validation on `Prev` keypress, matching `Input` field behavior.

## Reproducer

A form with a validated input on a non-first page:

```go
form := huh.NewForm(
    huh.NewGroup(huh.NewConfirm().Title("Enable?")),
    huh.NewGroup(
        huh.NewInput().
            Title("Required field").
            Validate(func(s string) error {
                if s == "" { return errors.New("required") }
                return nil
            }),
    ),
)
```

Press Tab to go forward, then Shift+Tab — navigation back is blocked.