### PR TITLE
fix(spinner): add space between spinner and title

### DIFF
--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -215,11 +215,14 @@ func (s *Spinner) Update(msg tea.Msg) (Model, tea.Cmd) {
 func (s *Spinner) View() string {
 	styles := s.theme.Theme(s.hasDarkBg)
 	s.spinner.Style = styles.Spinner
-	var title string
+	view := s.spinner.View()
 	if s.title != "" {
-		title = styles.Title.Render(s.title)
+		if !strings.HasSuffix(ansi.Strip(view), " ") {
+			view += " "
+		}
+		view += styles.Title.Render(s.title)
 	}
-	return s.spinner.View() + title
+	return view
 }
 
 // Run runs the spinner.

--- a/spinner/spinner_test.go
+++ b/spinner/spinner_test.go
@@ -12,6 +12,7 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestNewSpinner(t *testing.T) {
@@ -44,6 +45,18 @@ func TestSpinnerView(t *testing.T) {
 
 	if !strings.Contains(view, "Test") {
 		t.Errorf("Expected view to contain title 'Test', got '%s'", view)
+	}
+}
+
+func TestSpinnerTitleSpacing(t *testing.T) {
+	line := ansi.Strip(New().Type(Line).Title("Loading").View())
+	if !strings.Contains(line, "| Loading") {
+		t.Errorf("expected space between spinner and title, got %q", line)
+	}
+
+	dots := ansi.Strip(New().Type(Dots).Title("Loading").View())
+	if strings.Contains(dots, "  ") {
+		t.Errorf("expected single space between spinner and title, got %q", dots)
 	}
 }
 


### PR DESCRIPTION
This fixes charmbracelet/bubbles#999 (filed on the bubbles tracker, but the code lives here in huh's spinner).

The spinner title renders flush against the glyph for every type except Dots, for example `|Loading` instead of `| Loading`. Dots only looks right because its frames already end with a space.

`View()` joined the spinner and title with no separator. I add a single space when the rendered spinner doesn't already end with one, so Dots stays correct (no double space) and the other types get the space they were missing.

Added a test covering Line (space added) and Dots (no double space).
