### PR TITLE
fix(input): ignore stray Tab/Enter text on Windows

### DIFF
--- a/field_input.go
+++ b/field_input.go
@@ -358,7 +358,7 @@ func (i *Input) Update(msg tea.Msg) (Model, tea.Cmd) {
 	}
 
 	var cmd tea.Cmd
-	i.textinput, cmd = i.textinput.Update(msg)
+	i.textinput, cmd = i.textinput.Update(sanitizeKeyPressForInput(msg))
 	cmds = append(cmds, cmd)
 	i.accessor.Set(i.textinput.Value())
 

--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -299,7 +299,7 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	var cmd tea.Cmd
 	if m.filtering {
-		m.filter, cmd = m.filter.Update(msg)
+		m.filter, cmd = m.filter.Update(sanitizeKeyPressForInput(msg))
 		m.setSelectAllHelp()
 		cmds = append(cmds, cmd)
 	}

--- a/field_select.go
+++ b/field_select.go
@@ -330,7 +330,7 @@ func (s *Select[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	var cmd tea.Cmd
 	if s.filtering {
-		s.filter, cmd = s.filter.Update(msg)
+		s.filter, cmd = s.filter.Update(sanitizeKeyPressForInput(msg))
 	}
 
 	switch msg := msg.(type) {

--- a/field_text.go
+++ b/field_text.go
@@ -355,7 +355,7 @@ func (t *Text) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 	}
 
-	t.textarea, cmd = t.textarea.Update(msg)
+	t.textarea, cmd = t.textarea.Update(sanitizeKeyPressForInput(msg))
 	cmds = append(cmds, cmd)
 	t.accessor.Set(t.textarea.Value())
 

--- a/key_input.go
+++ b/key_input.go
@@ -1,0 +1,26 @@
+package huh
+
+import tea "charm.land/bubbletea/v2"
+
+// sanitizeKeyPressForInput clears stray Text from navigation keys before they
+// reach text inputs. On Windows, Tab and Enter key presses can include \t or \r
+// in Text while also using navigation key codes, which bubbles would otherwise
+// insert as literal characters.
+func sanitizeKeyPressForInput(msg tea.Msg) tea.Msg {
+	keyMsg, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return msg
+	}
+
+	key := keyMsg.Key()
+	switch key.Code {
+	case tea.KeyTab, tea.KeyEnter:
+		if key.Text == "" {
+			return msg
+		}
+		key.Text = ""
+		return tea.KeyPressMsg(key)
+	default:
+		return msg
+	}
+}

--- a/key_input_test.go
+++ b/key_input_test.go
@@ -1,0 +1,104 @@
+package huh
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestSanitizeKeyPressForInputClearsNavigationText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  tea.Key
+	}{
+		{name: "tab", key: tea.Key{Code: tea.KeyTab, Text: "\t"}},
+		{name: "shift tab", key: tea.Key{Code: tea.KeyTab, Mod: tea.ModShift, Text: "\t"}},
+		{name: "enter", key: tea.Key{Code: tea.KeyEnter, Text: "\r"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sanitized, ok := sanitizeKeyPressForInput(tea.KeyPressMsg(tt.key)).(tea.KeyPressMsg)
+			if !ok {
+				t.Fatalf("expected KeyPressMsg, got %T", sanitized)
+			}
+			if sanitized.Key().Text != "" {
+				t.Fatalf("expected empty text, got %q", sanitized.Key().Text)
+			}
+		})
+	}
+}
+
+func TestInputIgnoresWindowsNavigationKeyText(t *testing.T) {
+	t.Parallel()
+
+	field := NewInput()
+	field.Focus()
+
+	m, _ := field.Update(tea.KeyPressMsg(tea.Key{
+		Code: tea.KeyTab,
+		Text: "\t",
+	}))
+	field = m.(*Input)
+	if got, _ := field.GetValue().(string); got != "" {
+		t.Fatalf("expected empty value after tab, got %q", got)
+	}
+
+	m, _ = field.Update(tea.KeyPressMsg(tea.Key{
+		Code: tea.KeyEnter,
+		Text: "\r",
+	}))
+	field = m.(*Input)
+	if got, _ := field.GetValue().(string); got != "" {
+		t.Fatalf("expected empty value after enter, got %q", got)
+	}
+}
+
+func TestSanitizeKeyPressForInputPassthrough(t *testing.T) {
+	t.Parallel()
+
+	paste := tea.PasteMsg{Content: "hello"}
+	if got := sanitizeKeyPressForInput(paste); got != paste {
+		t.Fatalf("expected paste passthrough, got %#v", got)
+	}
+
+	plain := tea.KeyPressMsg(tea.Key{Code: tea.KeyTab})
+	if got := sanitizeKeyPressForInput(plain); got != plain {
+		t.Fatalf("expected unchanged tab keypress")
+	}
+
+	charKey := tea.KeyPressMsg(tea.Key{Code: 'a', Text: "a"})
+	if got := sanitizeKeyPressForInput(charKey); got != charKey {
+		t.Fatalf("expected unchanged character keypress")
+	}
+}
+
+func TestSanitizeKeyPressForInputPreservesModifiers(t *testing.T) {
+	t.Parallel()
+
+	shiftTab := tea.KeyPressMsg(tea.Key{Code: tea.KeyTab, Mod: tea.ModShift, Text: "\t"})
+	sanitized := sanitizeKeyPressForInput(shiftTab).(tea.KeyPressMsg)
+	if sanitized.Key().Mod != tea.ModShift {
+		t.Fatalf("expected shift modifier to be preserved")
+	}
+}
+
+func TestTextIgnoresWindowsNavigationKeyText(t *testing.T) {
+	t.Parallel()
+
+	field := NewText()
+	field.Focus()
+
+	m, _ := field.Update(tea.KeyPressMsg(tea.Key{
+		Code: tea.KeyTab,
+		Text: "\t",
+	}))
+	field = m.(*Text)
+	if got, _ := field.GetValue().(string); got != "" {
+		t.Fatalf("expected empty value after tab, got %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #286

## Summary

On Windows, Tab and Enter key presses can include stray `\t` or `\r` values in `Key.Text` while still using navigation key codes. Bubbles text inputs treat that text as user input and insert a literal space before Huh handles field navigation.

## Motivation

This reproduces the long-standing Windows bug where every Tab/Enter in `Input` and filter fields inserts an extra space, making forms difficult to use.

## Changes

- Add `sanitizeKeyPressForInput()` to clear `Text` from Tab/Enter `KeyPressMsg` values before forwarding them to bubbles.
- Apply the sanitizer in `Input`, `Text`, and active `Select` / `MultiSelect` filter inputs.
- Add regression tests for the sanitizer and `Input`/`Text` fields.

## Tests

- `go test ./...`

All packages pass locally.

## Notes

- This is a pragmatic Huh-level guard; bubbles could also ignore navigation-key `Text` upstream.
- `Text` fields still insert newlines on Enter via bubbles' newline binding; this change only prevents stray `\r` text from being inserted as a space before navigation handling.