### PR TITLE
fix(theme): align footer error message with help text

### DIFF
--- a/theme.go
+++ b/theme.go
@@ -111,7 +111,7 @@ func ThemeBase(bool) *Styles {
 	t.Focused.Base = lipgloss.NewStyle().PaddingLeft(1).BorderStyle(lipgloss.ThickBorder()).BorderLeft(true)
 	t.Focused.Card = t.Focused.Base
 	t.Focused.ErrorIndicator = lipgloss.NewStyle().SetString(" *")
-	t.Focused.ErrorMessage = lipgloss.NewStyle().SetString(" *")
+	t.Focused.ErrorMessage = lipgloss.NewStyle().SetString("*")
 	t.Focused.SelectSelector = lipgloss.NewStyle().SetString("> ")
 	t.Focused.NextIndicator = lipgloss.NewStyle().MarginLeft(1).SetString("→")
 	t.Focused.PrevIndicator = lipgloss.NewStyle().MarginRight(1).SetString("←")

--- a/theme_test.go
+++ b/theme_test.go
@@ -1,0 +1,15 @@
+package huh
+
+import "testing"
+
+func TestThemeBaseErrorMessageAlignment(t *testing.T) {
+	styles := ThemeBase(false)
+
+	if got := styles.Focused.ErrorIndicator.String(); got != " *" {
+		t.Fatalf("ErrorIndicator = %q, want %q", got, " *")
+	}
+
+	if got := styles.Focused.ErrorMessage.String(); got != "*" {
+		t.Fatalf("ErrorMessage = %q, want %q (no leading space so footer aligns with help)", got, "*")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #723.

Validation errors in the group footer were indented one column to the right of the help bar because `ErrorMessage` used a `" *"` prefix copied from `ErrorIndicator`.

`ErrorIndicator` keeps its leading space since it separates the field title from the asterisk (e.g. `Shell? *`). `ErrorMessage` is only used in `Group.Footer()` and now uses `"*"` so errors align with help text.

## Motivation

When both help and validation errors render in the footer, the extra leading space on `ErrorMessage` caused a visible column misalignment (reported with screenshots in #723).

## Changes

- `ThemeBase`: change `ErrorMessage` prefix from `" *"` to `"*"`
- Add `TestThemeBaseErrorMessageAlignment` to guard the distinction between `ErrorIndicator` and `ErrorMessage` prefixes

## Tests

- [x] `go test ./...` — all packages pass
- [x] `TestThemeBaseErrorMessageAlignment` — verifies `ErrorIndicator` stays `" *"` and `ErrorMessage` is `"*"`

## Notes

Lipgloss joins the style prefix and rendered text with a space, so only the leading space on the prefix caused the misalignment. All built-in themes inherit this from `ThemeBase` and only adjust foreground color on `ErrorMessage`.