### PR TITLE
fix(form): show quit keybind in field help footer

### DIFF
--- a/form.go
+++ b/form.go
@@ -438,10 +438,17 @@ func (f *Form) Help() help.Model {
 	return f.selector.Selected().help
 }
 
-// KeyBinds returns the current fields' keybinds.
+// KeyBinds returns the current fields' keybinds plus form-level bindings.
 func (f *Form) KeyBinds() []key.Binding {
 	group := f.selector.Selected()
-	return group.selector.Selected().KeyBinds()
+	if group.keymap != nil {
+		return group.KeyBinds()
+	}
+	binds := group.selector.Selected().KeyBinds()
+	if f.keymap != nil {
+		binds = append([]key.Binding{f.keymap.Quit}, binds...)
+	}
+	return binds
 }
 
 // Get returns a result from the form.

--- a/group.go
+++ b/group.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2/internal/selector"
@@ -389,12 +390,21 @@ func (g *Group) Content() string {
 	return content
 }
 
+// KeyBinds returns the selected field's keybindings plus form-level bindings.
+func (g *Group) KeyBinds() []key.Binding {
+	binds := g.selector.Selected().KeyBinds()
+	if g.keymap != nil {
+		binds = append([]key.Binding{g.keymap.Quit}, binds...)
+	}
+	return binds
+}
+
 // Footer renders the group's footer only (no content).
 func (g *Group) Footer() string {
 	var parts []string
 	errors := g.Errors()
 	if g.showHelp && len(errors) <= 0 {
-		parts = append(parts, g.help.ShortHelpView(g.selector.Selected().KeyBinds()))
+		parts = append(parts, g.help.ShortHelpView(g.KeyBinds()))
 	}
 	if g.showErrors {
 		for _, err := range errors {

--- a/huh_test.go
+++ b/huh_test.go
@@ -303,6 +303,11 @@ func TestInput(t *testing.T) {
 		t.Error("Expected field to contain help.")
 	}
 
+	if !strings.Contains(view, "ctrl+c quit") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected field help to include quit keybind.")
+	}
+
 	if field.GetValue() != text {
 		t.Error("Expected field value to be " + text)
 	}
@@ -507,6 +512,11 @@ func TestSelect(t *testing.T) {
 	if !strings.Contains(view, "↑ up • ↓ down • / filter • enter submit") {
 		t.Log(pretty.Render(view))
 		t.Error("Expected field to contain help.")
+	}
+
+	if !strings.Contains(view, "ctrl+c quit") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected field help to include quit keybind.")
 	}
 
 	// Submit

--- a/keymap.go
+++ b/keymap.go
@@ -106,7 +106,7 @@ type ConfirmKeyMap struct {
 // NewDefaultKeyMap returns a new default keymap.
 func NewDefaultKeyMap() *KeyMap {
 	return &KeyMap{
-		Quit: key.NewBinding(key.WithKeys("ctrl+c")),
+		Quit: key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit")),
 		Input: InputKeyMap{
 			AcceptSuggestion: key.NewBinding(key.WithKeys("ctrl+e"), key.WithHelp("ctrl+e", "complete")),
 			Prev:             key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "back")),


### PR DESCRIPTION
## Summary

Show the form-level `ctrl+c` quit binding in the help footer alongside each field's keybindings.

## Motivation

Fixes #721. Users could quit forms with `ctrl+c`, but the help footer only listed field-specific bindings (next, submit, etc.) and never showed quit.

## Changes

- Add help text to the default `Quit` binding in `NewDefaultKeyMap()`.
- Add `Group.KeyBinds()` to combine field bindings with the form-level quit binding.
- Update `Group.Footer()` and `Form.KeyBinds()` to use the combined bindings.
- Prepend quit so it remains visible when `ShortHelpView` truncates long binding lists (e.g. Select/MultiSelect).

## Tests

- `go test ./...` — all pass
- Extended `TestInput` and `TestSelect` to assert `ctrl+c quit` appears in help output

## Notes

Bubbletea integrations that call `form.Help().ShortHelpView(form.KeyBinds())` will now also include the quit binding, which matches the intended UX.