### PR TITLE
fix(form): skip groups that only contain skippable fields

### DIFF
--- a/field_note.go
+++ b/field_note.go
@@ -143,7 +143,7 @@ func (n *Note) Blur() tea.Cmd {
 func (n *Note) Error() error { return nil }
 
 // Skip returns whether the note should be skipped or should be blocking.
-func (n *Note) Skip() bool { return n.skip }
+func (n *Note) Skip() bool { return n.skip && !n.showNextButton }
 
 // Zoom returns whether the note should be zoomed.
 func (n *Note) Zoom() bool { return false }
@@ -287,9 +287,10 @@ func (n *Note) WithHeight(height int) Field {
 
 // WithPosition sets the position information of the note field.
 func (n *Note) WithPosition(p FieldPosition) Field {
-	// if the note is the only field on the screen,
-	// we shouldn't skip the entire group.
-	if p.Field == p.FirstField && p.Field == p.LastField {
+	// If the note is the only field in the entire form, don't skip it;
+	// otherwise a single skippable note in its own group should still be skipped
+	// when other groups contain interactive fields.
+	if p.Field == p.FirstField && p.Field == p.LastField && p.FirstGroup == p.LastGroup {
 		n.skip = false
 	}
 	n.keymap.Prev.SetEnabled(!p.IsFirst())

--- a/form.go
+++ b/form.go
@@ -516,7 +516,7 @@ func (f *Form) Init() tea.Cmd {
 		return true
 	})
 
-	if f.isGroupHidden(f.selector.Selected()) {
+	if f.isGroupHidden(f.selector.Selected()) || f.allFieldsSkippable(f.selector.Selected()) {
 		cmds = append(cmds, nextGroup)
 	}
 
@@ -637,6 +637,21 @@ func (f *Form) isGroupHidden(group *Group) bool {
 		return false
 	}
 	return hide()
+}
+
+func (f *Form) allFieldsSkippable(group *Group) bool {
+	if group.selector.Total() == 0 {
+		return false
+	}
+	allSkippable := true
+	group.selector.Range(func(_ int, field Field) bool {
+		if !field.Skip() {
+			allSkippable = false
+			return false
+		}
+		return true
+	})
+	return allSkippable
 }
 
 func (f *Form) getTheme() *Styles {

--- a/group.go
+++ b/group.go
@@ -201,7 +201,7 @@ func (g *Group) Init() tea.Cmd {
 
 	cmds = append(cmds, func() tea.Msg { return updateFieldMsg{} })
 
-	if g.selector.Selected().Skip() {
+	if g.selector.Selected().Skip() && g.selector.Total() > 1 {
 		if g.selector.OnLast() {
 			cmds = append(cmds, g.prevField()...)
 		} else if g.selector.OnFirst() {

--- a/huh_test.go
+++ b/huh_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -519,21 +520,36 @@ func TestSelect(t *testing.T) {
 
 // doAllUpdates updates the form with the given command, then continues updating it with any resultant commands from the update until no more are returned.
 func doAllUpdates(f *Form, cmd tea.Cmd) {
-	if cmd == nil {
-		return
-	}
-	var cmds []tea.Cmd
-	switch msg := cmd().(type) {
-	case tea.BatchMsg:
-		for _, subcommand := range msg {
-			doAllUpdates(f, subcommand)
+	for cmd != nil {
+		msg := cmd()
+		if subcmds := extractCmds(msg); len(subcmds) > 0 {
+			for _, subcmd := range subcmds {
+				doAllUpdates(f, subcmd)
+			}
+			cmd = nil
+			continue
 		}
-		return
-	default:
-		_, result := f.Update(msg)
-		cmds = append(cmds, result)
+		_, cmd = f.Update(msg)
 	}
-	doAllUpdates(f, tea.Batch(cmds...))
+}
+
+func extractCmds(msg tea.Msg) []tea.Cmd {
+	switch m := msg.(type) {
+	case tea.BatchMsg:
+		return m
+	default:
+		if reflect.TypeOf(msg).Name() == "sequenceMsg" {
+			v := reflect.ValueOf(msg)
+			if v.Kind() == reflect.Slice {
+				cmds := make([]tea.Cmd, v.Len())
+				for i := range cmds {
+					cmds[i] = v.Index(i).Interface().(tea.Cmd)
+				}
+				return cmds
+			}
+		}
+	}
+	return nil
 }
 
 func TestSelectDynamic(t *testing.T) {
@@ -1055,6 +1071,83 @@ func TestSkip(t *testing.T) {
 	if !strings.Contains(view, "┃ First") {
 		t.Log(pretty.Render(view))
 		t.Error("Expected first field to be focused")
+	}
+}
+
+func TestSkipSingleFieldGroup(t *testing.T) {
+	// A skippable note as the only field in a group should be skipped when
+	// other groups contain interactive fields.
+	f := NewForm(
+		NewGroup(
+			NewNote().Title("Welcome"),
+		),
+		NewGroup(
+			NewSelect[string]().
+				Options(NewOptions("A", "B")...).
+				Title("Choose"),
+		),
+	).WithWidth(30)
+
+	doAllUpdates(f, f.Init())
+	view := viewModel(f)
+
+	if strings.Contains(view, "Welcome") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected welcome note to be skipped")
+	}
+
+	if !strings.Contains(view, "Choose") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected select field to be focused")
+	}
+}
+
+func TestSkipSingleFieldOnlyGroup(t *testing.T) {
+	// A skippable note that is the only field in the entire form should still
+	// be shown.
+	f := NewForm(
+		NewGroup(
+			NewNote().Title("Welcome"),
+		),
+	).WithWidth(30)
+
+	f = batchUpdate(f, f.Init()).(*Form)
+	view := viewModel(f)
+
+	if !strings.Contains(view, "Welcome") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected welcome note to be shown when it is the only field")
+	}
+}
+
+func TestSkipNextButtonWelcomeGroup(t *testing.T) {
+	// A welcome note with an explicit next button should still be shown even
+	// when it is the only field in its group.
+	f := NewForm(
+		NewGroup(
+			NewNote().
+				Title("Welcome").
+				Description("Please read before continuing.").
+				Next(true),
+		),
+		NewGroup(
+			NewSelect[string]().
+				Options(NewOptions("A", "B")...).
+				Title("Choose"),
+		),
+	).WithWidth(30)
+
+	doAllUpdates(f, f.Init())
+	view := viewModel(f)
+
+	if !strings.Contains(view, "Welcome") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected welcome note with next button to be shown")
+	}
+
+	if strings.Contains(view, "Choose") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected select field to remain hidden until welcome is dismissed")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #468 by skipping groups that only contain skippable fields at form start, while preserving intentional blocking welcome screens and navigation behavior.

## Motivation

A skippable note as the only field in a group was not skipped when other groups contained interactive fields. The common workaround was adding a blank second note, which affected formatting.

## Changes

- Only force notes to be non-skippable when they are the only field in the **entire form** (not merely the only field in their group)
- Treat notes with `Next(true)` as blocking so burger-style welcome screens still appear
- Skip groups where every field is skippable during `Form.Init()`, similar to hidden groups
- Only auto-advance past skippable fields in `Group.Init()` when the group has more than one field
- Improve `doAllUpdates` test helper to process `tea.Sequence` messages from `Form.Init()`

## Tests

```console
go test ./...
```

All tests pass, including new regressions:
- `TestSkipSingleFieldGroup`
- `TestSkipSingleFieldOnlyGroup`
- `TestSkipNextButtonWelcomeGroup`

## Notes

- Consecutive skippable-only groups before an interactive group may still require multiple `nextGroup` transitions; only the first such group is skipped at init today. Happy to follow up if maintainers want full chaining.
- Backward navigation into a skippable-only group still shows the note, which seems preferable for welcome content.
