### PR TITLE
fix(note): skip lone skippable note groups on form init

### DIFF
--- a/field_note.go
+++ b/field_note.go
@@ -127,6 +127,12 @@ func (n *Note) NextLabel(label string) *Note {
 	return n
 }
 
+// Skippable sets whether the note is skipped during field navigation.
+func (n *Note) Skippable(skippable bool) *Note {
+	n.skip = skippable
+	return n
+}
+
 // Focus focuses the note field.
 func (n *Note) Focus() tea.Cmd {
 	n.focused = true
@@ -287,9 +293,9 @@ func (n *Note) WithHeight(height int) Field {
 
 // WithPosition sets the position information of the note field.
 func (n *Note) WithPosition(p FieldPosition) Field {
-	// if the note is the only field on the screen,
-	// we shouldn't skip the entire group.
-	if p.Field == p.FirstField && p.Field == p.LastField {
+	// If the note is the only field in the only group, keep it visible instead of
+	// skipping the entire form.
+	if p.Field == p.FirstField && p.Field == p.LastField && p.FirstGroup == p.LastGroup {
 		n.skip = false
 	}
 	n.keymap.Prev.SetEnabled(!p.IsFirst())

--- a/form.go
+++ b/form.go
@@ -507,18 +507,14 @@ func (f *Form) GetFocusedField() Field {
 
 // Init initializes the form.
 func (f *Form) Init() tea.Cmd {
+	f.advancePastPassiveGroups()
+
 	var cmds []tea.Cmd
 	f.selector.Range(func(i int, group *Group) bool {
-		if i == 0 {
-			group.active = true
-		}
+		group.active = i == f.selector.Index()
 		cmds = append(cmds, group.Init())
 		return true
 	})
-
-	if f.isGroupHidden(f.selector.Selected()) {
-		cmds = append(cmds, nextGroup)
-	}
 
 	cmds = append(cmds, tea.RequestWindowSize)
 	return tea.Sequence(cmds...)
@@ -637,6 +633,43 @@ func (f *Form) isGroupHidden(group *Group) bool {
 		return false
 	}
 	return hide()
+}
+
+func (f *Form) isGroupSkippable(group *Group) bool {
+	if group.selector.Total() == 0 {
+		return false
+	}
+	skippable := true
+	group.selector.Range(func(_ int, field Field) bool {
+		if !field.Skip() {
+			skippable = false
+			return false
+		}
+		return true
+	})
+	return skippable
+}
+
+func (f *Form) advancePastPassiveGroups() {
+	for {
+		current := f.selector.Selected()
+		if !f.isGroupHidden(current) && !f.isGroupSkippable(current) {
+			return
+		}
+		advanced := false
+		for i := f.selector.Index() + 1; i < f.selector.Total(); i++ {
+			g := f.selector.Get(i)
+			if f.isGroupHidden(g) {
+				continue
+			}
+			f.selector.SetIndex(i)
+			advanced = true
+			break
+		}
+		if !advanced {
+			return
+		}
+	}
 }
 
 func (f *Form) getTheme() *Styles {

--- a/group.go
+++ b/group.go
@@ -202,12 +202,17 @@ func (g *Group) Init() tea.Cmd {
 	cmds = append(cmds, func() tea.Msg { return updateFieldMsg{} })
 
 	if g.selector.Selected().Skip() {
-		if g.selector.OnLast() {
+		switch {
+		case g.selector.OnFirst() && g.selector.OnLast():
+			// Skippable-only groups are advanced in Form.Init. When the user
+			// navigates here explicitly, fall through and show the note.
+		case g.selector.OnLast():
 			cmds = append(cmds, g.prevField()...)
-		} else if g.selector.OnFirst() {
+			return tea.Batch(cmds...)
+		case g.selector.OnFirst():
 			cmds = append(cmds, g.nextField()...)
+			return tea.Batch(cmds...)
 		}
-		return tea.Batch(cmds...)
 	}
 
 	if g.active {

--- a/huh_test.go
+++ b/huh_test.go
@@ -897,10 +897,10 @@ func TestHideGroup(t *testing.T) {
 
 func TestHideGroupLastAndFirstGroupsNotHidden(t *testing.T) {
 	f := NewForm(
-		NewGroup(NewNote().Description("Bar")),
+		NewGroup(NewNote().Description("Bar").Skippable(false)),
 		NewGroup(NewNote().Description("Foo")).
 			WithHide(true),
-		NewGroup(NewNote().Description("Baz")),
+		NewGroup(NewNote().Description("Baz").Skippable(false)),
 	)
 
 	f = batchUpdate(f, f.Init()).(*Form)
@@ -934,9 +934,9 @@ func TestHideGroupLastAndFirstGroupsNotHidden(t *testing.T) {
 
 func TestPrevGroup(t *testing.T) {
 	f := NewForm(
-		NewGroup(NewNote().Description("Bar")),
-		NewGroup(NewNote().Description("Foo")),
-		NewGroup(NewNote().Description("Baz")),
+		NewGroup(NewNote().Description("Bar").Skippable(false)),
+		NewGroup(NewNote().Description("Foo").Skippable(false)),
+		NewGroup(NewNote().Description("Baz").Skippable(false)),
 	)
 
 	f = batchUpdate(f, f.Init()).(*Form)
@@ -1008,6 +1008,54 @@ func TestDynamicHelp(t *testing.T) {
 	if strings.Contains(view, "shift+tab") || strings.Contains(view, "submit") {
 		t.Log(pretty.Render(view))
 		t.Error("Expected help not to contain shift+tab or submit.")
+	}
+}
+
+func TestSkipLoneNoteGroup(t *testing.T) {
+	f := NewForm(
+		NewGroup(
+			NewNote().Title("Welcome").Description("Please read this message."),
+		),
+		NewGroup(
+			NewSelect[string]().
+				Options(NewOptions("A", "B")...).
+				Title("Choose one"),
+		),
+	).WithWidth(25)
+
+	f = batchUpdate(f, f.Init()).(*Form)
+	view := viewModel(f)
+
+	if strings.Contains(view, "Welcome") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected welcome note group to be skipped on init")
+	}
+
+	if !strings.Contains(view, "Choose one") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected select field to be focused")
+	}
+}
+
+func TestSkipLoneNoteGroupPrevNavigation(t *testing.T) {
+	f := NewForm(
+		NewGroup(
+			NewNote().Title("Welcome").Description("Please read this message."),
+		),
+		NewGroup(
+			NewSelect[string]().
+				Options(NewOptions("A", "B")...).
+				Title("Choose one"),
+		),
+	).WithWidth(25)
+
+	f = batchUpdate(f, f.Init()).(*Form)
+	f = batchUpdate(f, f.PrevGroup()).(*Form)
+	view := viewModel(f)
+
+	if !strings.Contains(view, "Welcome") {
+		t.Log(pretty.Render(view))
+		t.Error("Expected welcome note when navigating back to the first group")
 	}
 }
 


### PR DESCRIPTION
## Summary

Lone skippable notes in their own group are now skipped when a form initializes, so welcome screens can live in a dedicated group without blocking the first interactive field.

## Motivation

Fixes #468. Previously, `Note.WithPosition` forced `skip = false` whenever a note was the only field in its group, which prevented welcome-message groups from being skipped even when `Skip()` returned `true`.

## Changes

- Only disable note skipping when the note is the sole field in the sole group of the entire form
- Add `Form.advancePastPassiveGroups()` to skip hidden and skippable-only groups during `Init`
- Stop auto-prev navigation for single skippable fields in `Group.Init` so explicit back-navigation still shows the note
- Add `Note.Skippable(bool)` for display-only note pages that should remain visible on init

## Tests

- `go test ./... -count=1` — all pass
- Added `TestSkipLoneNoteGroup` and `TestSkipLoneNoteGroupPrevNavigation`
- Updated existing note group tests to use `Skippable(false)` where a lone note page must remain visible on init

## Notes

This is a small behavior change: multi-group forms with lone default-skippable note groups now start on the next interactive group. Use `Note.Skippable(false)` to keep a note page visible on init.