### PR TITLE
fix(note): skip lone skippable note groups on form start

### DIFF
--- a/examples/skip/main.go
+++ b/examples/skip/main.go
@@ -1,39 +1,32 @@
 package main
 
 import (
+	"fmt"
+
 	"charm.land/huh/v2"
 )
 
 func main() {
-	f := huh.NewForm(
+	var burger string
+
+	err := huh.NewForm(
+		// A lone skippable note in its own group is auto-skipped on start.
 		huh.NewGroup(
 			huh.NewNote().
-				Title("Charmburger").
-				Description("Welcome to _Charmburger™_."),
-
-			huh.NewSelect[string]().
-				Options(huh.NewOptions("Charmburger Classic", "Chickwich", "Fishburger", "Charmpossible™ Burger")...).
-				Title("Choose your burger").
-				Description("At Charm we truly have a burger for everyone."),
-
-			huh.NewNote().
-				Title("🍔"),
+				Title("Welcome").
+				Description("This note is skipped automatically so the form opens on the next group."),
 		),
 
 		huh.NewGroup(
-			huh.NewNote().
-				Title("Buy 1 get 1 free").
-				Description("Welcome back to _Charmburger™_."),
-
 			huh.NewSelect[string]().
-				Options(huh.NewOptions("Charmburger Classic", "Chickwich", "Fishburger", "Charmpossible™ Burger")...).
+				Options(huh.NewOptions("Charmburger Classic", "Chickwich", "Fishburger")...).
 				Title("Choose your burger").
-				Description("At Charm we truly have a burger for everyone."),
-
-			huh.NewNote().
-				Title("🍔"),
+				Value(&burger),
 		),
-	)
+	).Run()
+	if err != nil {
+		panic(err)
+	}
 
-	f.Run()
+	fmt.Printf("You chose %q\n", burger)
 }

--- a/field_note.go
+++ b/field_note.go
@@ -143,7 +143,7 @@ func (n *Note) Blur() tea.Cmd {
 func (n *Note) Error() error { return nil }
 
 // Skip returns whether the note should be skipped or should be blocking.
-func (n *Note) Skip() bool { return n.skip }
+func (n *Note) Skip() bool { return n.skip && !n.showNextButton }
 
 // Zoom returns whether the note should be zoomed.
 func (n *Note) Zoom() bool { return false }
@@ -287,9 +287,9 @@ func (n *Note) WithHeight(height int) Field {
 
 // WithPosition sets the position information of the note field.
 func (n *Note) WithPosition(p FieldPosition) Field {
-	// if the note is the only field on the screen,
+	// if the note is the only field in the entire form,
 	// we shouldn't skip the entire group.
-	if p.Field == p.FirstField && p.Field == p.LastField {
+	if p.IsFirst() && p.IsLast() {
 		n.skip = false
 	}
 	n.keymap.Prev.SetEnabled(!p.IsFirst())

--- a/form.go
+++ b/form.go
@@ -518,6 +518,8 @@ func (f *Form) Init() tea.Cmd {
 
 	if f.isGroupHidden(f.selector.Selected()) {
 		cmds = append(cmds, nextGroup)
+	} else if f.isGroupSkippable(f.selector.Selected()) {
+		cmds = append(cmds, nextGroup)
 	}
 
 	cmds = append(cmds, tea.RequestWindowSize)
@@ -600,6 +602,9 @@ func (f *Form) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 		}
 		f.selector.Selected().active = true
+		if f.isGroupSkippable(f.selector.Selected()) {
+			return f, nextGroup
+		}
 		return f, f.selector.Selected().Init()
 
 	case prevGroupMsg:
@@ -629,6 +634,21 @@ func (f *Form) Update(msg tea.Msg) (Model, tea.Cmd) {
 	}
 
 	return f, cmd
+}
+
+func (f *Form) isGroupSkippable(group *Group) bool {
+	if group.selector.Total() == 0 {
+		return false
+	}
+	skippable := true
+	group.selector.Range(func(_ int, field Field) bool {
+		if !field.Skip() {
+			skippable = false
+			return false
+		}
+		return true
+	})
+	return skippable
 }
 
 func (f *Form) isGroupHidden(group *Group) bool {

--- a/group.go
+++ b/group.go
@@ -201,7 +201,7 @@ func (g *Group) Init() tea.Cmd {
 
 	cmds = append(cmds, func() tea.Msg { return updateFieldMsg{} })
 
-	if g.selector.Selected().Skip() {
+	if g.selector.Selected().Skip() && g.selector.Total() > 1 {
 		if g.selector.OnLast() {
 			cmds = append(cmds, g.prevField()...)
 		} else if g.selector.OnFirst() {

--- a/huh_test.go
+++ b/huh_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -530,6 +531,14 @@ func doAllUpdates(f *Form, cmd tea.Cmd) {
 		}
 		return
 	default:
+		if v := reflect.ValueOf(msg); v.Kind() == reflect.Slice && v.Type().Name() == "sequenceMsg" {
+			for i := 0; i < v.Len(); i++ {
+				if sub, ok := v.Index(i).Interface().(tea.Cmd); ok {
+					doAllUpdates(f, sub)
+				}
+			}
+			return
+		}
 		_, result := f.Update(msg)
 		cmds = append(cmds, result)
 	}
@@ -854,8 +863,8 @@ func TestHideGroup(t *testing.T) {
 	f := NewForm(
 		NewGroup(NewNote().Description("Foo")).
 			WithHide(true),
-		NewGroup(NewNote().Description("Bar")),
-		NewGroup(NewNote().Description("Baz")),
+		NewGroup(NewInput().Title("Bar")),
+		NewGroup(NewInput().Title("Baz")),
 		NewGroup(NewNote().Description("Qux")).
 			WithHideFunc(func() bool { return false }).
 			WithHide(true),
@@ -869,21 +878,21 @@ func TestHideGroup(t *testing.T) {
 	}
 
 	// should have no effect as previous group is hidden
-	f.Update(prevGroup())
+	f.Update(func() tea.Msg { return prevGroup() })
 
 	if v := f.View(); !strings.Contains(v, "Bar") {
 		t.Log(pretty.Render(v))
 		t.Error("expected Bar to be visible")
 	}
 
-	f.Update(nextGroup())
+	f = batchUpdate(f, func() tea.Msg { return nextGroup() }).(*Form)
 
 	if v := f.View(); !strings.Contains(v, "Baz") {
 		t.Log(pretty.Render(v))
 		t.Error("expected Baz to be visible")
 	}
 
-	f.Update(nextGroup())
+	f = batchUpdate(f, func() tea.Msg { return nextGroup() }).(*Form)
 
 	if v := f.View(); strings.Contains(v, "Qux") {
 		t.Log(pretty.Render(v))
@@ -897,10 +906,10 @@ func TestHideGroup(t *testing.T) {
 
 func TestHideGroupLastAndFirstGroupsNotHidden(t *testing.T) {
 	f := NewForm(
-		NewGroup(NewNote().Description("Bar")),
+		NewGroup(NewInput().Title("Bar")),
 		NewGroup(NewNote().Description("Foo")).
 			WithHide(true),
-		NewGroup(NewNote().Description("Baz")),
+		NewGroup(NewInput().Title("Baz")),
 	)
 
 	f = batchUpdate(f, f.Init()).(*Form)
@@ -1008,6 +1017,61 @@ func TestDynamicHelp(t *testing.T) {
 	if strings.Contains(view, "shift+tab") || strings.Contains(view, "submit") {
 		t.Log(pretty.Render(view))
 		t.Error("Expected help not to contain shift+tab or submit.")
+	}
+}
+
+func TestSkipSingleNoteGroup(t *testing.T) {
+	f := NewForm(
+		NewGroup(
+			NewNote().Title("Welcome"),
+		),
+		NewGroup(
+			NewSelect[string]().
+				Options(NewOptions("A", "B")...).
+				Title("Choose"),
+		),
+	).WithWidth(25)
+
+	doAllUpdates(f, f.Init())
+	view := viewModel(f)
+
+	if strings.Contains(view, "Welcome") {
+		t.Log(pretty.Render(view))
+		t.Error("expected welcome note group to be skipped on init")
+	}
+
+	if !strings.Contains(view, "Choose") {
+		t.Log(pretty.Render(view))
+		t.Error("expected select field to be focused")
+	}
+}
+
+func TestSkipInteractiveNoteGroup(t *testing.T) {
+	f := NewForm(
+		NewGroup(
+			NewNote().
+				Title("Charmburger").
+				Description("Welcome").
+				Next(true),
+		),
+		NewGroup(
+			NewSelect[string]().
+				Options(NewOptions("A", "B")...).
+				Title("Choose"),
+		),
+	).WithWidth(25)
+
+	doAllUpdates(f, f.Init())
+	view := viewModel(f)
+
+	if !strings.Contains(view, "Charmburger") {
+		t.Log(pretty.Render(view))
+		t.Error("expected interactive note group to remain visible on init")
+	}
+
+	if strings.Contains(view, "Choose") {
+		t.Log(pretty.Render(view))
+		t.Error("expected select field to remain unfocused until note is advanced")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes auto-skip behavior for forms where the first group contains only a skippable note (for example, a welcome screen) and later groups contain interactive fields.

## Motivation

Fixes #468

A skippable note in a group with only one field was not skipped when additional groups existed. The form would focus the welcome note instead of advancing to the next group.

## Changes

- Scope the note `skip = false` override to the sole field in the entire form (`IsFirst() && IsLast()`), not just the sole field in a group.
- Add `isGroupSkippable()` and skip all-skippable groups on form init and forward group navigation.
- Keep single-field group auto-skip in `Group.Init()` disabled; form-level logic handles that case.
- Treat interactive notes with `Next(true)` as non-skippable via `Skip()`.
- Update `examples/skip` to demonstrate the welcome-note auto-skip pattern.
- Add regression tests for both auto-skip and interactive-note cases.

## Tests

```bash
go test ./... -count=1
```

All tests pass.

## Notes

- Backward navigation into an auto-skipped group still shows the note, which matches existing within-group skip behavior.
- The test helper `doAllUpdates` now drains `tea.Sequence` messages so init-time group skipping is covered in unit tests.