### PR TITLE
fix(multiselect): respect limit when toggling a filtered option

### DIFF
--- a/field_multiselect.go
+++ b/field_multiselect.go
@@ -423,7 +423,7 @@ func (m *MultiSelect[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 		case key.Matches(msg, m.keymap.Toggle) && !m.filtering:
 			for i, option := range m.options.val {
 				if option.Key == m.filteredOptions[m.cursor].Key {
-					if !m.options.val[m.cursor].selected && m.limit > 0 && m.numSelected() >= m.limit {
+					if !m.options.val[i].selected && m.limit > 0 && m.numSelected() >= m.limit {
 						break
 					}
 					selected := m.options.val[i].selected

--- a/huh_test.go
+++ b/huh_test.go
@@ -741,6 +741,37 @@ func TestMultiSelectFiltering(t *testing.T) {
 	})
 }
 
+func TestMultiSelectLimitWithFilter(t *testing.T) {
+	field := NewMultiSelect[string]().
+		Options(NewOptions("Foo", "Bar", "Baz", "Qux", "Quux")...).
+		Title("Which ones?").
+		Limit(2)
+	f := NewForm(NewGroup(field))
+	f.Update(f.Init())
+
+	// Select the first two options, reaching the limit.
+	f.Update(keypress('x')) // toggle Foo
+	f.Update(keypress('j')) // move to Bar
+	f.Update(keypress('x')) // toggle Bar
+
+	// Apply a filter that only shows the (unselected) Qux/Quux options, then
+	// accept it so filteredOptions is a strict subset while filtering is off.
+	f.Update(keypress('/'))
+	f.Update(keypress('Q'))
+	f.Update(codeKeypress(tea.KeyEnter))
+
+	// Attempting to select another option while at the limit must be a no-op.
+	f.Update(keypress('x'))
+
+	value, ok := field.GetValue().([]string)
+	if !ok {
+		t.Fatal("Expected multi-select value to be a slice of string")
+	}
+	if len(value) != 2 {
+		t.Errorf("Expected selection to remain at the limit of 2, got %d: %v", len(value), value)
+	}
+}
+
 func TestSelectPageNavigation(t *testing.T) {
 	opts := NewOptions(
 		"Qux",


### PR DESCRIPTION
When a MultiSelect has a `Limit` and an accepted filter narrows the visible options, toggling could push the selection past the limit: the limit check indexed the full options slice with the filtered cursor (`m.options.val[m.cursor]`) instead of the matched option, so under an active filter it read a different option's `selected` state. This uses the matched option's own index (`i`), matching the line right below it.
