### PR TITLE
fix(select): show matches hidden above the cursor when filtering

### DIFF
--- a/field_select.go
+++ b/field_select.go
@@ -329,6 +329,7 @@ func (s *Select[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 	s.updateViewportSize()
 
 	var cmd tea.Cmd
+	filterBefore := s.filter.Value()
 	if s.filtering {
 		s.filter, cmd = s.filter.Update(msg)
 	}
@@ -492,24 +493,36 @@ func (s *Select[T]) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 
 		if s.filtering {
-			s.filteredOptions = s.options.val
-			if s.filter.Value() != "" {
-				s.filteredOptions = nil
-				for _, option := range s.options.val {
-					if s.filterFunc(option.Key) {
-						s.filteredOptions = append(s.filteredOptions, option)
-					}
-				}
-			}
-			if len(s.filteredOptions) > 0 {
-				s.selected = min(s.selected, len(s.filteredOptions)-1)
-			}
+			s.updateFilteredOptions(filterBefore)
 		}
 
 		s.ensureCursorVisible()
 	}
 
 	return s, cmd
+}
+
+func (s *Select[T]) updateFilteredOptions(previousFilter string) {
+	s.filteredOptions = s.options.val
+	if s.filter.Value() != "" {
+		s.filteredOptions = nil
+		for _, option := range s.options.val {
+			if s.filterFunc(option.Key) {
+				s.filteredOptions = append(s.filteredOptions, option)
+			}
+		}
+	}
+	if len(s.filteredOptions) == 0 {
+		return
+	}
+	if s.filter.Value() != previousFilter {
+		// ensureCursorVisible only scrolls the minimum needed, so the offset
+		// has to be reset too or earlier matches stay hidden above the window.
+		s.selected = 0
+		s.viewport.GotoTop()
+		return
+	}
+	s.selected = min(s.selected, len(s.filteredOptions)-1)
 }
 
 func (s *Select[T]) updateValue() {

--- a/huh_test.go
+++ b/huh_test.go
@@ -741,6 +741,31 @@ func TestMultiSelectFiltering(t *testing.T) {
 	})
 }
 
+func TestSelectFilteringShowsMatchesAboveTheCursor(t *testing.T) {
+	// Bar and Baz sit at opposite ends of the list, so filtering for "ba"
+	// while the cursor is at the bottom leaves Bar above the visible window.
+	opts := NewOptions("Bar", "Qux", "Quux", "Foo", "Corge", "Grault", "Garply", "Waldo", "Fred", "Baz")
+
+	field := NewSelect[string]().Options(opts...).Title("Choose")
+	f := NewForm(NewGroup(field)).WithHeight(6)
+	f.Update(f.Init())
+
+	// Move to the end of the list, scrolling the viewport away from the top.
+	batchUpdate(f.Update(keypress('G')))
+
+	batchUpdate(f.Update(keypress('/')))
+	batchUpdate(f.Update(keypress('b')))
+	m := batchUpdate(f.Update(keypress('a')))
+
+	view := viewModel(m)
+	for _, want := range []string{"Bar", "Baz"} {
+		if !strings.Contains(view, want) {
+			t.Log(pretty.Render(view))
+			t.Errorf("filtered list is missing %q, which matches the filter", want)
+		}
+	}
+}
+
 func TestSelectPageNavigation(t *testing.T) {
 	opts := NewOptions(
 		"Qux",


### PR DESCRIPTION
Fixes #669.

## The problem

Filtering a `Select` can show fewer matches than actually match. Scrolling up
reveals the rest one at a time, and typing another character then deleting it
also brings them back — which is what makes it look intermittent.

Whether it happens depends on where the cursor was before you filtered, so it
only shows up on lists long enough to scroll.

## Cause

When the filter changes, the previous cursor is carried over and clamped to the
new match count:

```go
s.selected = min(s.selected, len(s.filteredOptions)-1)
```

The viewport is still scrolled to wherever that cursor sat in the unfiltered
list. `ensureCursorVisible()` then runs, but it only ever scrolls the minimum
needed to bring the cursor into view, so it anchors the window on the clamped
cursor and leaves every earlier match above it, out of sight.

It can't self-correct, either: `viewport.SetContent()` runs later during `View`,
so at the point the scroll decision is made the viewport still holds the
previous, longer content and the offset is never clamped against the new length.

## The fix

Move to the first match whenever the filter text *changes*, which re-anchors the
viewport at the top. Navigating within an unchanged filter keeps its position, so
arrow keys behave as before.

Ten options, `WithHeight(6)`, cursor sent to the bottom with `G`, then filtered
with `/ba` — `Bar` and `Baz` both match:

**Before**
```
┃ /ba
┃ > Baz
┃
┃
```

**After**
```
┃ /ba
┃ > Bar
┃   Baz
┃
```

## Testing

Adds `TestSelectFilteringShowsMatchesAboveTheCursor`, which fails without the
change. The existing suite passes.

Note this does change behaviour: filtering now lands on the first match rather
than a clamped previous cursor. That matches `bubbles/list` and survey, and no
existing test relies on the old position — but flagging it explicitly in case
you'd rather preserve the cursor and fix the offset another way.
