### PR TITLE
fix(group): don't panic on a group with no fields

### DIFF
--- a/form.go
+++ b/form.go
@@ -690,7 +690,7 @@ func (f *Form) styles() FormStyles {
 
 // View renders the form.
 func (f *Form) View() string {
-	if f.quitting {
+	if f.quitting || f.selector.Empty() {
 		return ""
 	}
 

--- a/form.go
+++ b/form.go
@@ -430,17 +430,31 @@ func (f *Form) UpdateFieldPositions() *Form {
 
 // Errors returns the current groups' errors.
 func (f *Form) Errors() []error {
+	if f.selector.Empty() {
+		return nil
+	}
 	return f.selector.Selected().Errors()
 }
 
 // Help returns the current groups' help.
 func (f *Form) Help() help.Model {
+	if f.selector.Empty() {
+		return help.New()
+	}
 	return f.selector.Selected().help
 }
 
 // KeyBinds returns the current fields' keybinds.
+//
+// It returns nil if the form has no groups, or the current group has no fields.
 func (f *Form) KeyBinds() []key.Binding {
+	if f.selector.Empty() {
+		return nil
+	}
 	group := f.selector.Selected()
+	if group.selector.Empty() {
+		return nil
+	}
 	return group.selector.Selected().KeyBinds()
 }
 
@@ -501,12 +515,28 @@ func (f *Form) PrevField() tea.Cmd {
 }
 
 // GetFocusedField returns the focused form field.
+//
+// It returns nil if the form has no groups, or the current group has no fields.
 func (f *Form) GetFocusedField() Field {
-	return f.selector.Selected().selector.Selected()
+	if f.selector.Empty() {
+		return nil
+	}
+	group := f.selector.Selected()
+	if group.selector.Empty() {
+		return nil
+	}
+	return group.selector.Selected()
 }
 
 // Init initializes the form.
 func (f *Form) Init() tea.Cmd {
+	// a form without groups has nothing to ask, so it is already done.
+	if f.selector.Total() == 0 {
+		f.quitting = true
+		f.State = StateCompleted
+		return f.SubmitCmd
+	}
+
 	var cmds []tea.Cmd
 	f.selector.Range(func(i int, group *Group) bool {
 		if i == 0 {
@@ -526,8 +556,9 @@ func (f *Form) Init() tea.Cmd {
 
 // Update updates the form.
 func (f *Form) Update(msg tea.Msg) (Model, tea.Cmd) {
-	// If the form is aborted or completed there's no need to update it.
-	if f.State != StateNormal {
+	// If the form is aborted, completed, or has nothing to ask, there's no
+	// need to update it.
+	if f.State != StateNormal || f.selector.Empty() {
 		return f, nil
 	}
 
@@ -570,8 +601,10 @@ func (f *Form) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	case nextFieldMsg:
 		// Form is progressing to the next field, let's save the value of the current field.
-		field := group.selector.Selected()
-		f.results[field.GetKey()] = field.GetValue()
+		if !group.selector.Empty() {
+			field := group.selector.Selected()
+			f.results[field.GetKey()] = field.GetValue()
+		}
 
 	case nextGroupMsg:
 		if len(group.Errors()) > 0 {
@@ -632,6 +665,11 @@ func (f *Form) Update(msg tea.Msg) (Model, tea.Cmd) {
 }
 
 func (f *Form) isGroupHidden(group *Group) bool {
+	// a group without fields has nothing to prompt for, so treat it as
+	// hidden and let the form move on to the next one.
+	if group.selector.Empty() {
+		return true
+	}
 	hide := group.hide
 	if hide == nil {
 		return false
@@ -669,7 +707,8 @@ func (f *Form) RunWithContext(ctx context.Context) error {
 	f.SubmitCmd = tea.Quit
 	f.CancelCmd = tea.Interrupt
 
-	if f.selector.Total() == 0 {
+	if f.selector.Empty() {
+		f.State = StateCompleted
 		return nil
 	}
 

--- a/group.go
+++ b/group.go
@@ -201,6 +201,10 @@ func (g *Group) Init() tea.Cmd {
 
 	cmds = append(cmds, func() tea.Msg { return updateFieldMsg{} })
 
+	if g.selector.Empty() {
+		return tea.Batch(cmds...)
+	}
+
 	if g.selector.Selected().Skip() {
 		if g.selector.OnLast() {
 			cmds = append(cmds, g.prevField()...)
@@ -220,6 +224,9 @@ func (g *Group) Init() tea.Cmd {
 
 // nextField moves to the next field.
 func (g *Group) nextField() []tea.Cmd {
+	if g.selector.Empty() {
+		return []tea.Cmd{nextGroup}
+	}
 	blurCmd := g.selector.Selected().Blur()
 	if g.selector.OnLast() {
 		return []tea.Cmd{blurCmd, nextGroup}
@@ -237,6 +244,9 @@ func (g *Group) nextField() []tea.Cmd {
 
 // prevField moves to the previous field.
 func (g *Group) prevField() []tea.Cmd {
+	if g.selector.Empty() {
+		return []tea.Cmd{prevGroup}
+	}
 	blurCmd := g.selector.Selected().Blur()
 	if g.selector.OnFirst() {
 		return []tea.Cmd{blurCmd, prevGroup}
@@ -303,6 +313,12 @@ func (g *Group) styles() GroupStyles { return g.getTheme().Group }
 func (g *Group) getContent() (int, string) {
 	var fields strings.Builder
 	offset := 0
+
+	// a group can legitimately have no fields, e.g. when they were all
+	// filtered out before building it. there's nothing to render.
+	if g.selector.Empty() {
+		return offset, ""
+	}
 
 	gap := g.getTheme().FieldSeparator.Render()
 
@@ -393,7 +409,7 @@ func (g *Group) Content() string {
 func (g *Group) Footer() string {
 	var parts []string
 	errors := g.Errors()
-	if g.showHelp && len(errors) <= 0 {
+	if g.showHelp && len(errors) <= 0 && !g.selector.Empty() {
 		parts = append(parts, g.help.ShortHelpView(g.selector.Selected().KeyBinds()))
 	}
 	if g.showErrors {

--- a/huh_test.go
+++ b/huh_test.go
@@ -957,6 +957,76 @@ func TestHideGroupLastAndFirstGroupsNotHidden(t *testing.T) {
 	}
 }
 
+func TestEmptyGroup(t *testing.T) {
+	// fields can all be filtered out before the group is built, e.g. when
+	// every value was already given on the command line.
+	var fields []Field
+
+	f := NewForm(NewGroup(fields...))
+	f = batchUpdate(f, f.Init()).(*Form)
+
+	if v := ansi.Strip(f.View()); strings.TrimSpace(v) != "" {
+		t.Log(pretty.Render(v))
+		t.Error("expected an empty group to render nothing")
+	}
+
+	if v := f.GetFocusedField(); v != nil {
+		t.Error("expected no focused field")
+	}
+
+	f.Update(nextGroup())
+
+	if v := f.State; v != StateCompleted {
+		t.Error("should have been completed")
+	}
+}
+
+func TestEmptyForm(t *testing.T) {
+	// a form with no groups at all: nothing to ask, so it is already done.
+	f := NewForm()
+	f = batchUpdate(f, f.Init()).(*Form)
+
+	if v := ansi.Strip(f.View()); strings.TrimSpace(v) != "" {
+		t.Log(pretty.Render(v))
+		t.Error("expected an empty form to render nothing")
+	}
+
+	if v := f.GetFocusedField(); v != nil {
+		t.Error("expected no focused field")
+	}
+
+	if v := f.KeyBinds(); v != nil {
+		t.Error("expected no keybinds")
+	}
+
+	if v := f.Errors(); v != nil {
+		t.Error("expected no errors")
+	}
+
+	if v := f.State; v != StateCompleted {
+		t.Error("should have been completed")
+	}
+
+	if err := f.Run(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestEmptyGroupIsSkipped(t *testing.T) {
+	f := NewForm(
+		NewGroup(),
+		NewGroup(NewNote().Description("Bar")),
+	)
+
+	f = batchUpdate(f, f.Init()).(*Form)
+	f.Update(nextGroup())
+
+	if v := ansi.Strip(f.View()); !strings.Contains(v, "Bar") {
+		t.Log(pretty.Render(v))
+		t.Error("expected Bar to be visible")
+	}
+}
+
 func TestPrevGroup(t *testing.T) {
 	f := NewForm(
 		NewGroup(NewNote().Description("Bar")),

--- a/internal/selector/selector.go
+++ b/internal/selector/selector.go
@@ -53,6 +53,11 @@ func (s *Selector[T]) Index() int {
 	return s.index
 }
 
+// Empty returns true if the selector has no items.
+func (s *Selector[T]) Empty() bool {
+	return len(s.items) == 0
+}
+
 // Total returns the total number of items.
 func (s *Selector[T]) Total() int {
 	return len(s.items)


### PR DESCRIPTION
`NewGroup` panics when it is given no fields:

```go
var fields []huh.Field // every value came from a flag, so nothing is left to ask
_ = huh.NewForm(huh.NewGroup(fields...)).Run()
```

```
panic: runtime error: index out of range [0] with length 0
	huh/internal/selector.(*Selector[...]).Selected(...) selector.go:48
	huh.(*Group).getContent(...) group.go:304
	huh.(*Group).Content(...) group.go:382
	huh.(*Group).rawHeight(...) group.go:356
	huh.NewGroup(...) group.go:58
```

`NewGroup` measures its height, which reaches for `selector.Selected()` before checking whether anything is selected.

This is easy to hit from a CLI that builds its form from what the user did not pass on the command line: give every answer as a flag and the slice is empty, so the program crashes on exactly the input that needed no prompting.

### What this changes

- adds `Selector.Empty()` and guards the field accesses that assume a selection, in `Group.Init`, `nextField`, `prevField`, `getContent` and `Footer`, and in `Form.KeyBinds`, `GetFocusedField` and the `nextFieldMsg` handler
- treats a group with no fields as hidden, so a form containing one moves along to the next group rather than showing an empty page
- treats a form with no groups as already complete: `Init` marks it `StateCompleted`, and `Update`, `Errors`, `Help`, `KeyBinds` and `GetFocusedField` return zero values instead of panicking. `NewForm().Init()` panicked the same way before this branch.

`GetFocusedField` and `KeyBinds` can now return nil where they previously panicked; both say so in their doc comments.

### Tests

Three added: an empty group renders nothing and completes, a form with an empty group followed by a real one displays the real one, and a form with no groups at all completes without panicking. `go test ./...` passes.
