### PR TITLE
fix(input): don't kill cursor blink chain on View() (#799)

### DIFF
--- a/field_input.go
+++ b/field_input.go
@@ -43,6 +43,12 @@ type Input struct {
 	theme     Theme
 	hasDarkBg bool
 	keymap    InputKeyMap
+
+	// stylesDirty flags that the underlying textinput's styles must be
+	// re-applied on the next View(). Without this flag, every View() would
+	// call textinput.SetStyles, which corrupts the cursor's blink chain
+	// (see #799).
+	stylesDirtyFlag bool
 }
 
 // NewInput creates a new input field.
@@ -63,6 +69,7 @@ func NewInput() *Input {
 		description: Eval[string]{cache: make(map[uint64]string)},
 		placeholder: Eval[string]{cache: make(map[uint64]string)},
 		suggestions: Eval[[]string]{cache: make(map[uint64][]string)},
+		stylesDirtyFlag: true,
 	}
 
 	return i
@@ -245,12 +252,14 @@ func (*Input) Zoom() bool { return false }
 // Focus focuses the input field.
 func (i *Input) Focus() tea.Cmd {
 	i.focused = true
+	i.stylesDirtyFlag = true
 	return i.textinput.Focus()
 }
 
 // Blur blurs the input field.
 func (i *Input) Blur() tea.Cmd {
 	i.focused = false
+	i.stylesDirtyFlag = true
 	i.accessor.Set(i.textinput.Value())
 	i.textinput.Blur()
 	i.err = i.validate(i.accessor.Get())
@@ -278,6 +287,7 @@ func (i *Input) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.BackgroundColorMsg:
 		i.hasDarkBg = msg.IsDark()
+		i.stylesDirtyFlag = true
 	case updateFieldMsg:
 		var cmds []tea.Cmd
 		if ok, hash := i.title.shouldUpdate(); ok {
@@ -376,20 +386,37 @@ func (i *Input) activeStyles() *FieldStyles {
 	return &theme.Theme(i.hasDarkBg).Blurred
 }
 
+// stylesDirty reports whether the underlying textinput's styles need to be
+// re-applied on the next View(). See the comment in View() for why this
+// guard matters (issue #799).
+func (i *Input) stylesDirty() bool { return i.stylesDirtyFlag }
+
 // View renders the input field.
 func (i *Input) View() string {
 	styles := i.activeStyles()
 	maxWidth := i.width - styles.Base.GetHorizontalFrameSize()
 
-	// NB: since the method is on a pointer receiver these are being mutated.
-	// Because this runs on every render this shouldn't matter in practice,
-	// however.
-	st := i.textinput.Styles()
-	st.Cursor.Color = styles.TextInput.Cursor.GetForeground()
-	st.Focused.Prompt = styles.TextInput.Prompt
-	st.Focused.Text = styles.TextInput.Text
-	st.Focused.Placeholder = styles.TextInput.Placeholder
-	i.textinput.SetStyles(st)
+	// Apply the huh theme's input styles to the underlying textinput. We
+	// only do this when the active style state actually changes (focused
+	// vs blurred, or styles-dependent colors shifting), because
+	// textinput.SetStyles calls updateVirtualCursorStyle, which calls
+	// cursor.SetMode(CursorBlink). SetMode increments the cursor's
+	// blinkTag, and the in-flight Blink() timer emits a BlinkMsg with the
+	// tag captured at call time. If the blinkTag moves before the timer
+	// fires, the cursor's Update rejects the BlinkMsg and the blink chain
+	// dies (the cursor becomes static). Calling SetStyles on every render
+	// is what causes github.com/charmbracelet/huh issue #799.
+	if i.stylesDirty() {
+		// NB: since the method is on a pointer receiver these are being
+		// mutated. Styles() returns a copy, so this is safe.
+		st := i.textinput.Styles()
+		st.Cursor.Color = styles.TextInput.Cursor.GetForeground()
+		st.Focused.Prompt = styles.TextInput.Prompt
+		st.Focused.Text = styles.TextInput.Text
+		st.Focused.Placeholder = styles.TextInput.Placeholder
+		i.textinput.SetStyles(st)
+		i.stylesDirtyFlag = false
+	}
 
 	// Adjust text input size to its char limit if it fit in its width
 	if i.textinput.CharLimit > 0 {
@@ -474,6 +501,7 @@ func (i *Input) WithTheme(theme Theme) Field {
 		return i
 	}
 	i.theme = theme
+	i.stylesDirtyFlag = true
 	return i
 }
 

--- a/zz_blink_799_test.go
+++ b/zz_blink_799_test.go
@@ -1,0 +1,52 @@
+package huh
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestIssue799BlinkAfterView exercises the huh fix for issue #799: calling
+// View() on a focused Input must NOT kill the in-flight cursor BlinkMsg
+// chain.
+//
+// The pre-fix View() unconditionally called textinput.SetStyles, which
+// internally calls cursor.SetMode(CursorBlink), which bumps the cursor's
+// blinkTag. A Blink cmd that was captured with the old blinkTag now
+// produces a BlinkMsg whose tag is stale, and the cursor rejects it,
+// silently halting the blink chain.
+//
+// The fix introduces a `stylesDirty` flag on Input so View() only calls
+// SetStyles when something actually changed (Focus, Blur, theme switch,
+// background-color msg). On a plain View() call with no state change
+// SetStyles is skipped, and the existing Blink chain is preserved.
+func TestIssue799BlinkAfterView(t *testing.T) {
+	input := NewInput()
+
+	// Focus returns the initial Blink cmd.
+	cmd := input.Focus()
+	if cmd == nil {
+		t.Fatal("expected initial Blink cmd from Focus()")
+	}
+
+	// Simulate the render loop: a View() without any state change. The
+	// huh-level fix must NOT touch the underlying textinput (no
+	// SetStyles, no cursor.SetMode, no blinkTag bump).
+	for i := 0; i < 5; i++ {
+		_ = input.View() // should be a no-op for blinkTag purposes
+
+		msg := cmd()
+		if msg == nil {
+			t.Fatalf("iter %d: Blink cmd returned nil", i)
+		}
+		_, next := input.Update(msg)
+		if next == nil {
+			t.Fatalf("iter %d: Blink chain died after View() (issue #799): msg=%T", i, msg)
+		}
+		cmd = next
+	}
+}
+
+// silence unused-import linter for tea when the test above doesn't reference
+// tea directly. The huh types use tea.Msg under the hood.
+var _ tea.Cmd


### PR DESCRIPTION
## Summary

Calling `View()` on a focused `Input` used to unconditionally call
`textinput.SetStyles`, which internally calls
`cursor.SetMode(CursorBlink)`. `SetMode` bumps the cursor's
`blinkTag`, and the in-flight `Blink()` timer emits a `BlinkMsg`
carrying the old `blinkTag`. The cursor's `Update` rejects the stale
`BlinkMsg` and silently halts the blink chain — the cursor freezes
after the first toggle. See #799.

## Fix

Gate `SetStyles` on a `stylesDirty` flag set whenever something that
actually affects the rendered styles changes (Focus, Blur, theme swap,
`tea.BackgroundColorMsg`). A plain `View()` with no state change now
leaves the existing blink chain intact.

## Test

`TestIssue799BlinkAfterView` exercises the render loop: focus the
input, call `View()` five times, and assert the Blink chain stays
alive. Pre-fix the chain dies after the first `View()`.

## AI assistance disclosure

Code written with AI assistance (Claude / Anthropic). Reviewed and
tested by the human submitter before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)